### PR TITLE
Add example using seed param to get consistent outputs

### DIFF
--- a/examples/reproducible-outputs/README.md
+++ b/examples/reproducible-outputs/README.md
@@ -1,0 +1,4 @@
+# reproducible-outputs
+
+This example demonstrates how to get reproducible outputs from the models by providing a seed value in the options parameter.
+The seed value needs to be consistent across requests in order to get similar responses from the model.

--- a/examples/reproducible-outputs/main.py
+++ b/examples/reproducible-outputs/main.py
@@ -1,7 +1,7 @@
 from ollama import chat
 
 
-options = {"temperature": 0.1, "seed": 100}
+options = {"temperature": 0, "seed": 100}
 
 messages = [
   {

--- a/examples/reproducible-outputs/main.py
+++ b/examples/reproducible-outputs/main.py
@@ -1,0 +1,14 @@
+from ollama import chat
+
+
+options = {"temperature": 0.1, "seed": 100}
+
+messages = [
+  {
+    'role': 'user',
+    'content': 'Why is the sky blue?',
+  },
+]
+
+response = chat('mistral', messages=messages, options=options)
+print(response['message']['content'])


### PR DESCRIPTION
Updates the examples directory with an example that demonstrates how to reprodduce similar outputs.