### PR TITLE
bump httpx to 0.26.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -159,13 +159,13 @@ trio = ["trio (>=0.22.0,<0.23.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.25.2"
+version = "0.26.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.25.2-py3-none-any.whl", hash = "sha256:a05d3d052d9b2dfce0e3896636467f8a5342fb2b902c819428e1ac65413ca118"},
-    {file = "httpx-0.25.2.tar.gz", hash = "sha256:8b8fcaa0c8ea7b05edd69a094e63a2094c4efcb48129fb757361bc423c0ad9e8"},
+    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
+    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
 ]
 
 [package.dependencies]
@@ -534,4 +534,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a516e97b6a647d7fb86935723d10ac863b6ca1debb23e1f3fd17307dddbba1aa"
+content-hash = "87ddeee10efee7320f7e755a479e89950ca1b42f7ab48900fd01703031d1e5b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/jmorganca/ollama-python"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = "^0.25.2"
+httpx = "^0.26.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,9 @@ h11==0.14.0 ; python_version >= "3.8" and python_version < "4.0" \
 httpcore==1.0.2 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:096cc05bca73b8e459a1fc3dcf585148f63e534eae4339559c9b8a8d6399acc7 \
     --hash=sha256:9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535
-httpx==0.25.2 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:8b8fcaa0c8ea7b05edd69a094e63a2094c4efcb48129fb757361bc423c0ad9e8 \
-    --hash=sha256:a05d3d052d9b2dfce0e3896636467f8a5342fb2b902c819428e1ac65413ca118
+httpx==0.26.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf \
+    --hash=sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd
 idna==3.6 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f


### PR DESCRIPTION
I am the creator on [Ollama Conversation](https://github.com/ej52/hass-ollama-conversation), I am wanting to get the integration listed on Home Assistant itself but in order to do that this condition needs to be met [communication-with-devicesservices](https://developers.home-assistant.io/docs/creating_component_code_review#4-communication-with-devicesservices).

So I need to switch from making direct API calls to using this library, however the version of **httpx** required by this library has conflicts with Home Assistant requirements.

This PR just bumps httpx version to 0.26.0 in order to meet the requirements.