### PR TITLE
Fixes URL parsing when basic auth is included in the URL.

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -718,8 +718,10 @@ def _parse_host(host: Optional[str]) -> str:
   elif scheme == 'https':
     port = 443
 
-  split = urllib.parse.urlsplit('://'.join([scheme, hostport]))
+  split = urllib.parse.urlsplit('://'.join([scheme, hostport]), allow_fragments=True)
   host = split.hostname or '127.0.0.1'
   port = split.port or port
-
-  return f'{scheme}://{host}:{port}'
+  parsed_url = f'{scheme}://{host}:{port}'
+  if split.username and split.password:
+    parsed_url=f'{scheme}://{split.username}:{split.password}@{host}:{port}'
+  return parsed_url


### PR DESCRIPTION
Ollama may be protected by a reverse proxy enforcing basic auth.

When the Ollama URL contains basic auth elements, ollama-python removed them from the URL leading in a HTTP 401 ERROR.
```
from ollama import Client
client = Client(host='http://<username>:<password>@<ip>:<port>/')
```

This patch fixes the parsing of the URL so that basic auth elements are not removed.
