### PR TITLE
Loosen httpx constraint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -159,13 +159,13 @@ trio = ["trio (>=0.22.0,<0.23.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.25.2"
+version = "0.27.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.25.2-py3-none-any.whl", hash = "sha256:a05d3d052d9b2dfce0e3896636467f8a5342fb2b902c819428e1ac65413ca118"},
-    {file = "httpx-0.25.2.tar.gz", hash = "sha256:8b8fcaa0c8ea7b05edd69a094e63a2094c4efcb48129fb757361bc423c0ad9e8"},
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [package.dependencies]
@@ -534,4 +534,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a516e97b6a647d7fb86935723d10ac863b6ca1debb23e1f3fd17307dddbba1aa"
+content-hash = "246c99fc63b2d2826ad5e9eb7ff8549963ba70e66a7b2b976c5d8ab8956d69b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/jmorganca/ollama-python"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = "^0.25.2"
+httpx = "<1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
@@ -19,6 +19,7 @@ pytest-cov = "^4.1.0"
 pytest-httpserver = "^1.0.8"
 pillow = "^10.2.0"
 ruff = "^0.1.8"
+httpx = "0.27.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This loosens the httpx constraint to allow any version <1. I have pinned httpx as a dev dependency to the latest version of httpx (0.27.0) so tests don't just start breaking one day.

Pinning dependencies in a library forces downstream consumers to follow the requirements of the library. In the case of Home Assistant, this is not compatible as Home Assistant aggressively follows the latest version of httpx.

Unblocks https://github.com/home-assistant/core/pull/113962

Replaces #42 