### PR TITLE
fix 'content' check on messages in chat()

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -169,7 +169,7 @@ class Client(BaseClient):
         raise TypeError('messages must be a list of Message or dict-like objects')
       if not (role := message.get('role')) or role not in ['system', 'user', 'assistant']:
         raise RequestError('messages must contain a role and it must be one of "system", "user", or "assistant"')
-      if not message.get('content'):
+      if 'content' not in message:
         raise RequestError('messages must contain content')
       if images := message.get('images'):
         message['images'] = [_encode_image(image) for image in images]
@@ -449,7 +449,7 @@ class AsyncClient(BaseClient):
         raise TypeError('messages must be a list of strings')
       if not (role := message.get('role')) or role not in ['system', 'user', 'assistant']:
         raise RequestError('messages must contain a role and it must be one of "system", "user", or "assistant"')
-      if not message.get('content'):
+      if 'content' not in message:
         raise RequestError('messages must contain content')
       if images := message.get('images'):
         message['images'] = [_encode_image(image) for image in images]


### PR DESCRIPTION
In `chat()` in `Client` and `AsyncClient`, if `message['content']` is `""`,

the following would raise an error since `bool("")` also returns `False` like `bool(None)`:
```python
if not message.get('content'):
  raise RequestError('messages must contain content')
```
Doing the following would fix it:
```python
if 'content' not in message:
  raise RequestError('messages must contain content')
```

As far as I know ollama does not explicitly prohibit empty content in messages.