### PR TITLE
Add py.typed to mark the library as typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://ollama.ai"
 repository = "https://github.com/jmorganca/ollama-python"
+include = [
+    "ollama/py.typed"
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,6 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://ollama.ai"
 repository = "https://github.com/jmorganca/ollama-python"
-include = [
-    "ollama/py.typed"
-]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Removes an error like this:

    error: Skipping analyzing "ollama":
    module is installed, but missing library stubs or py.typed marker  [import-untyped]

when running mypy over code that uses the library.