### PR TITLE
Add type overloads for chat() method in _client.py

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from hashlib import sha256
 from base64 import b64encode, b64decode
 
-from typing import Any, AnyStr, Union, Optional, Sequence, Mapping, Literal
+from typing import Any, AnyStr, Union, Optional, Sequence, Mapping, Literal, overload
 
 import sys
 
@@ -141,6 +141,30 @@ class Client(BaseClient):
       },
       stream=stream,
     )
+
+  @overload
+  def chat(
+    self,
+    model: str = '',
+    messages: Optional[Sequence[Message]] = None,
+    stream: Literal[False] = False,
+    format: Literal['', 'json'] = '',
+    options: Optional[Options] = None,
+    keep_alive: Optional[Union[float, str]] = None,
+  ) -> Mapping[str, Any]:
+    ...
+
+  @overload
+  def chat(
+    self,
+    model: str = '',
+    messages: Optional[Sequence[Message]] = None,
+    stream: Literal[True] = True,
+    format: Literal['', 'json'] = '',
+    options: Optional[Options] = None,
+    keep_alive: Optional[Union[float, str]] = None,
+  ) -> Iterator[Mapping[str, Any]]:
+    ...
 
   def chat(
     self,


### PR DESCRIPTION
This PR adds two type overloads in `_client.py` to reduce type warnings.
The PR should only affect typing and no logic.

## Before PR:

```python
import ollama
response = ollama.chat(model='llama2', messages=[
  {
    'role': 'user',
    'content': 'Why is the sky blue?',
  },
])
# before PR: response is now Union[Mapping[str, Any], Iterator[Mapping[str, Any]]]
print(response['message']['content'])
```

## New behaviour:

```python
response = ollama.chat(model='llama2', stream=False, ...)
# response is of type Mapping[str, Any]

response = ollama.chat(model='llama2', stream=True, ...)
# response is of type Iterator[Mapping[str, Any]]

response = ollama.chat(model='llama2', ...)
# response is also of type Mapping[str, Any], since stream=False is the default.
```
