### PR TITLE
fix: annotation in AsyncClient.embedding

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -474,7 +474,7 @@ class AsyncClient(BaseClient):
     prompt: str = '',
     options: Optional[Options] = None,
     keep_alive: Optional[Union[float, str]] = None,
-  ) -> Sequence[float]:
+  ) -> Mapping[str, Sequence[float]]:
     response = await self._request(
       'POST',
       '/api/embeddings',


### PR DESCRIPTION
The same question as #114 .

In #114, annotation of `Client.embedding` is modified, but `AsyncClient` is forgotten.