### PR TITLE
fix: Ensure JSON response is properly parsed in generate function when format is set to 'json'

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -156,7 +156,7 @@ class Client(BaseClient):
     if not model:
       raise RequestError('must provide a model')
 
-    return self._request_stream(
+    response = self._request_stream(
       'POST',
       '/api/generate',
       json={
@@ -174,6 +174,13 @@ class Client(BaseClient):
       },
       stream=stream,
     )
+
+    
+    if format == 'json':
+        if 'response' in response and isinstance(response['response'], str):
+          response['response'] = json.loads(response['response'])
+
+    return response
 
   @overload
   def chat(


### PR DESCRIPTION
When I set` format` as `"json"`, my response looks like this:

`{'model': 'llama3', 'created_at': '2024-06-28T05:44:32.12715Z', 'response': '{"results": [\n{\n"entity_type": "IMEI",\n"text": "06-184755-866851-3"\n}\n]}\n\n \n\n ', 'done': True, 'done_reason': 'stop', 'context': [], 'total_duration': 4528553708, 'load_duration': 2316500, 'prompt_eval_count': 437, 'prompt_eval_duration': 2743245000, 'eval_count': 32, 'eval_duration': 1781380000}`


As you can notice, although it indeed returns a JSON object, the previous code parses the `'response'` as a string (hence the presence of `\n` characters and type checking result).

After I added some code to correctly parse the JSON response, the response now looks like this:

`{'model': 'llama3', 'created_at': '2024-06-28T09:16:56.417739Z', 'response': {'results': [{'entity_type': 'IMEI', 'text': '06-184755-866851-3'}]}, 'done': True, 'done_reason': 'stop', 'context':`

It becomes cleaner and matches my expected format.