### PR TITLE
fix: PydanticUserError: Please use `typing_extensions.TypedDict` inst…

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -3,10 +3,10 @@ from typing import Any, TypedDict, Sequence, Literal
 
 import sys
 
-if sys.version_info < (3, 11):
-  from typing_extensions import NotRequired
+if sys.version_info < (3, 12):
+  from typing_extensions import NotRequired, TypedDict
 else:
-  from typing import NotRequired
+  from typing import NotRequired, TypedDict
 
 
 class BaseGenerateResponse(TypedDict):


### PR DESCRIPTION
…ead of `typing.TypedDict` on Python < 3.12.