### PR TITLE
Autogen Tool, ToolFunction, Parameters, Property schema when opt-in to using type-hinted function params

### DIFF
--- a/examples/tool-functions/main.py
+++ b/examples/tool-functions/main.py
@@ -1,0 +1,74 @@
+import typing as t
+import ollama
+
+from ollama._toolfuncs import annotated_tool  # Pull Request coming soon
+
+
+def lookup_function(function_name: str):
+    return globals()[function_name]
+
+
+# Example Function 1
+@annotated_tool
+def get_current_weather(city: t.Annotated[str, "The name of the city"]):
+    # mock response
+    return 75.0, "Farenheit"
+
+
+def run_example_1():
+    response_1 = ollama.chat(
+        model="llama3.1",
+        messages=[{"role": "user", "content": "What is the weather in San Francisco?"}],
+        tools=[get_current_weather.tool_schema],
+    )
+
+    fn_call_1 = response_1["message"]["tool_calls"][0]["function"]
+    fn_resp_1 = lookup_function(fn_call_1["name"])(city=fn_call_1["arguments"]["city"])
+    assert fn_resp_1 == (75.0, "Farenheit")
+    print("SUCCESS: get_current_weather is called")
+
+
+run_example_1()
+
+
+# Example Function 2
+@annotated_tool
+def sort_fruit_names(
+    fruit_names: t.Annotated[t.List[str], "a list of fruit names"]
+) -> t.List:
+    return sorted(fruit_names)
+
+
+def run_example_2():
+    response_2 = ollama.chat(
+        model="llama3.1",
+        messages=[
+            {
+                "role": "user",
+                "content": "Sort the fruit names strawberry, kiwi, banana, pineapple, passion fruit, mango",
+            }
+        ],
+        tools=[
+            get_current_weather.tool_schema,  # not expecting a match
+            sort_fruit_names.tool_schema,  # expecting a match
+        ],
+    )
+    print(response_2["message"]["tool_calls"])
+    assert len(response_2["message"]["tool_calls"]) == 1
+    fn_call_2 = response_2["message"]["tool_calls"][0]["function"]
+    fruit_names_arg = fn_call_2["arguments"]["fruit_names"]
+    print(f"model found {len(fruit_names_arg)} fruit names: {fruit_names_arg}")
+    fn_resp_2 = lookup_function(fn_call_2["name"])(fruit_names=fruit_names_arg)
+    print(fn_resp_2)
+    assert fn_resp_2 == [
+        "banana",
+        "kiwi",
+        "mango",
+        "passion fruit",
+        "pineapple",
+        "strawberry",
+    ]
+    print("SUCCESS: sort_fruit_names is called")
+
+
+run_example_2()

--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -8,6 +8,7 @@ from ollama._types import (
   RequestError,
   ResponseError,
 )
+from ollama._toolfuncs import annotated_tool
 
 __all__ = [
   'Client',

--- a/ollama/_toolfuncs.py
+++ b/ollama/_toolfuncs.py
@@ -1,0 +1,157 @@
+import inspect
+from enum import EnumMeta
+from types import NoneType
+from typing import (
+    Annotated,
+    Dict,
+    List,
+    Sequence,
+    TypedDict,
+    Union,
+    get_origin as get_type_origin,
+    get_args as get_type_args,
+)
+from ._types import Tool, ToolFunction, Parameters, Property
+
+
+class CannotParseParameters(Exception):
+    pass
+
+
+PYTHON_TYPE_TO_SCHEMA_TYPE = {
+    bool: "boolean",
+    float: "number",
+    int: "integer",
+    list: "array",
+    str: "string",
+}
+
+
+class ParsedAnnotation(TypedDict):
+    description: str
+    is_optional: bool
+    param_type: str
+    property_enum: Sequence[str]  # matches Property.enum
+
+
+def _get_param_info(param: inspect.Parameter) -> ParsedAnnotation:
+    """Given an inspected function's Parameter, determine
+    the relevant ToolFunction parameter/property metadata"""
+    is_optional = param.default not in (inspect.Parameter.empty, NoneType)
+    atn, raw_type = param.annotation, None
+    enum_values: List[str] = None
+    if get_type_origin(atn) == Annotated:
+        # we expect the outer most Annotation is the one that
+        # contains the description text
+        desc_text = atn.__metadata__[0]
+    else:
+        # fallback strategy, just wordify the snake case param name
+        desc_text = param.name.replace("_", " ")
+
+    if get_type_origin(atn) is None:
+        # support/gracefully handle un-Annotated params
+        # e.g. param type just one of the built-in python types
+        if isinstance(atn, EnumMeta):
+            # support unannotated e.g. 'foo: ExampleEnum = ExampleEnum.THING'
+            raw_type = str
+            enum_values: List[str] = [e.value for e in atn]
+        else:
+            # e.g. the type hint is just a basic type e.g. str, int, float
+            raw_type = atn
+        return ParsedAnnotation(
+            param_type=raw_type,
+            is_optional=is_optional,
+            description=desc_text,
+            property_enum=enum_values,
+        )
+
+    cur_atn = atn
+    while raw_type is None:
+        # we need to keep drilling into nested Annotations to find
+        # the user's intended function param type
+        try:
+            # e.g. Annotated[str, "description"] has two args
+            #   index 0: the 'str' class
+            #   index 1: the text description
+            if get_type_origin(cur_atn) is list:
+                # found Annotated[List[...]]
+                raw_type = list
+            elif isinstance(cur_atn, EnumMeta):
+                raw_type = str  # see Property.enum support scope
+                enum_values: List[str] = [e.value for e in cur_atn]
+            else:
+                candidate = get_type_args(cur_atn)[0]
+                if candidate in PYTHON_TYPE_TO_SCHEMA_TYPE:
+                    raw_type = candidate
+        except IndexError:
+            raise CannotParseParameters(
+                f"ERROR: not expected to parse {param.name=} "
+                f"where {param.annotation=}"
+            )
+
+        if get_type_origin(cur_atn) == Union and get_type_args(cur_atn)[1] is NoneType:
+            # found Optional annotation, i.e. Optional is actually Union[Any, None]
+            is_optional = True
+
+        # drill down to the next annotation level
+        cur_atn = candidate
+
+    return ParsedAnnotation(
+        param_type=raw_type,
+        is_optional=is_optional,
+        description=desc_text,
+        property_enum=enum_values,
+    )
+
+
+PYTHON_TYPE_TO_SCHEMA_TYPE = {
+    bool: "boolean",
+    float: "number",
+    int: "integer",
+    list: "array",
+    str: "string",
+}
+
+
+def annotated_tool(orig_fn) -> Tool:
+    """
+    Decorates a typing-annotated function and reflects on its parameter properties to automatically
+    create the necessary ToolFunction + Parameter + Property schema for the tools= field in ollama.chat
+    """
+    sig = inspect.signature(orig_fn)
+    props: Dict[str, Property] = {}
+    required_params = set(sig.parameters.keys())
+    for param_name, param in sig.parameters.items():
+        if not param.annotation:
+            # warn this parameter will be ignored by the ollama ToolFunction spec
+            continue
+        param_info = _get_param_info(param)
+
+        if param_info["is_optional"]:
+            required_params.discard(param_name)
+
+        if param_info["param_type"] is None:
+            raise Exception(param_name)
+
+        optional_prop_kwargs = {}
+        if "property_enum" in param_info:
+            # don't put enum in the Property if not present in annotation
+            optional_prop_kwargs["enum"] = param_info["property_enum"]
+
+        props[param_name] = Property(
+            type=PYTHON_TYPE_TO_SCHEMA_TYPE[param_info["param_type"]],
+            description=param_info["description"],
+            is_optional=param_info["is_optional"],
+            **optional_prop_kwargs,
+        )
+    orig_fn.tool_schema = {
+        "type": "function",
+        "function": ToolFunction(
+            name=orig_fn.__name__,
+            description=orig_fn.__doc__,
+            parameters=Parameters(
+                type="object", required=list(required_params), properties=props
+            ),
+        ),
+    }
+    return orig_fn

--- a/ollama/_toolfuncs.py
+++ b/ollama/_toolfuncs.py
@@ -1,6 +1,12 @@
 import inspect
 from enum import EnumMeta
-from types import NoneType
+
+try:
+    # Python 3.10+
+    from types import NoneType
+except ImportError:
+    NoneType = type(None)
+
 from typing import (
     Annotated,
     Dict,

--- a/ollama/_toolfuncs.py
+++ b/ollama/_toolfuncs.py
@@ -136,9 +136,6 @@ def annotated_tool(orig_fn) -> Tool:
         if param_info["is_optional"]:
             required_params.discard(param_name)
 
-        if param_info["param_type"] is None:
-            raise Exception(param_name)
-
         optional_prop_kwargs = {}
         if "property_enum" in param_info:
             # don't put enum in the Property if not present in annotation

--- a/tests/test_toolfuncs.py
+++ b/tests/test_toolfuncs.py
@@ -1,7 +1,6 @@
 from enum import Enum
 import typing as t
-import ollama._toolfuncs as ollama_tools
-
+import ollama
 
 class ExampleEnum(Enum):
     FOO = "foo"
@@ -9,7 +8,7 @@ class ExampleEnum(Enum):
     BAZ = "baz"
 
 
-@ollama_tools.annotated_tool
+@ollama.annotated_tool
 def example_1(
     expr_1: t.Annotated[str, "first simple str value"],
     expr_2: t.Annotated[str, "second simple str value"],

--- a/tests/test_toolfuncs.py
+++ b/tests/test_toolfuncs.py
@@ -1,0 +1,128 @@
+from enum import Enum
+import typing as t
+import ollama._toolfuncs as ollama_tools
+
+
+class ExampleEnum(Enum):
+    FOO = "foo"
+    BAR = "bar"
+    BAZ = "baz"
+
+
+@ollama_tools.annotated_tool
+def example_1(
+    expr_1: t.Annotated[str, "first simple str value"],
+    expr_2: t.Annotated[str, "second simple str value"],
+    req_int_arg: t.Annotated[int, "a required integer"],
+    req_float_arg: t.Annotated[float, "any real number"],
+    req_list_arg_1: t.Annotated[list, "any builtin list"],
+    req_list_arg_2: t.Annotated[t.List[t.Any], "any typed List"],
+    req_enum_1: t.Annotated[ExampleEnum, "required foo bar or baz"],
+    opt_arg_1: t.Annotated[t.Optional[str], "an optional string"] = None,
+    opt_enum_1: t.Annotated[t.Optional[ExampleEnum], "optional foo bar or baz"] = None,
+    opt_enum_2: ExampleEnum = ExampleEnum.FOO,
+    opt_builtin_str_1: str = "foobar",
+    opt_builtin_int_1: int = 1e6,
+    opt_builtin_float_1: float = 1.0,
+    opt_builtin_list_1: list = None,
+):
+    """a test case for Annotating a tool function's parameters.
+    the docstring of the function is the Function.description."""
+    return NotImplementedError("not in test scope to check function response")
+
+
+def test_function_description():
+    assert example_1.tool_schema["function"]["description"] == example_1.__doc__
+
+
+def test_annotated_str():
+    for k in ["expr_1", "expr_2"]:
+        _ = example_1.tool_schema["function"]["parameters"]["properties"][k]
+        assert _["type"] == "string"
+        assert "simple str value" in _["description"]
+        assert _["is_optional"] is False
+
+
+def test_annotated_int():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["req_int_arg"]
+    assert _["type"] == "integer"
+    assert _["description"] == "a required integer"
+    assert _["is_optional"] is False
+
+
+def test_annotated_float():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["req_float_arg"]
+    assert _["type"] == "number"
+    assert _["description"] == "any real number"
+    assert _["is_optional"] is False
+
+
+def test_annotated_builtin_list():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["req_list_arg_1"]
+    assert _["type"] == "array"
+    assert _["description"] == "any builtin list"
+    assert _["is_optional"] is False
+
+
+def test_annotated_typed_list():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["req_list_arg_2"]
+    assert _["type"] == "array"
+    assert _["description"] == "any typed List"
+    assert _["is_optional"] is False
+
+
+def test_annotated_optional_builtin_str():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"][
+        "opt_builtin_str_1"
+    ]
+    assert _["type"] == "string"
+    assert _["description"] == "opt builtin str 1"
+    assert _["is_optional"] is True
+
+
+def test_annotated_optional_builtin_int():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"][
+        "opt_builtin_int_1"
+    ]
+    assert _["type"] == "integer"
+    assert _["description"] == "opt builtin int 1"
+    assert _["is_optional"] is True
+
+
+def test_annotated_optional_builtin_float():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"][
+        "opt_builtin_float_1"
+    ]
+    assert _["type"] == "number"
+    assert _["description"] == "opt builtin float 1"
+    assert _["is_optional"] is True
+
+
+def test_annotated_optional_builtin_list():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"][
+        "opt_builtin_list_1"
+    ]
+    assert _["type"] == "array"
+    assert _["description"] == "opt builtin list 1"
+    assert _["is_optional"] is True
+
+
+def test_annotated_enum_1():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["req_enum_1"]
+    assert _["type"] == "string"
+    assert _["description"] == "required foo bar or baz"
+    assert _["is_optional"] is False
+
+
+def test_optional_annotated_enum_1():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["opt_enum_1"]
+    assert _["type"] == "string"
+    assert _["description"] == "optional foo bar or baz"
+    assert _["is_optional"] is True
+
+
+def test_optional_unannotated_enum_1():
+    _ = example_1.tool_schema["function"]["parameters"]["properties"]["opt_enum_2"]
+    assert _["type"] == "string"
+    assert _["description"] == "opt enum 2"
+    assert _["is_optional"] is True

--- a/tests/test_toolfuncs.py
+++ b/tests/test_toolfuncs.py
@@ -1,6 +1,10 @@
-from enum import Enum
 import typing as t
 import ollama
+import pytest
+
+from enum import Enum
+from ollama._toolfuncs import CannotParseParameters
+
 
 class ExampleEnum(Enum):
     FOO = "foo"
@@ -125,3 +129,10 @@ def test_optional_unannotated_enum_1():
     assert _["type"] == "string"
     assert _["description"] == "opt enum 2"
     assert _["is_optional"] is True
+
+
+def test_unsupported_parameter():
+    def foo(unsupported: t.Annotated[t.Callable, "a function being passed"]):
+        """this is not supported - expect CannotParseParameters"""
+
+    assert pytest.raises(CannotParseParameters, ollama.annotated_tool, foo)


### PR DESCRIPTION
# 😩 Problem

In the [API docs](https://github.com/ollama/ollama/blob/main/docs/api.md#chat-request-with-tools) for passing in `tools=` spec sequence to the chat model, the docs suggest developers hand-craft the `Tool`, `ToolFunction`, `Parameters`, `Property` schema'ed docs to the `tools=` arg. This is very repetitive.

For example, building up this JSON is laborious, given we already have defined the tool calling function.

```json
{
      "type": "function",
      "function": {
        "name": "get_current_weather",
        "description": "Get the current weather for a location",
        "parameters": { 😩
          "type": "object",
          "properties": {
            "location": {
              "type": "string",
              "description": "The location to get the weather for, e.g. San Francisco, CA"
            }, 😩
            "format": {
              "type": "string",
              "description": "The format to return the weather in, e.g. 'celsius' or 'fahrenheit'",
              "enum": ["celsius", "fahrenheit"] 😩
            }
          },
          "required": ["location", "format"] 😩
        }
      }
```

# Improvement Proposal

I propose we can solve it by giving users an option to type hint their functions and get back an automatic schema.

The scope is:

- **must only** use Python standard library and native `type` `typing` helpers
- your literal function name in `.py` is the function name in the spec, no need to type it twice
- `function` docstring **is** the `Function` `description`, this should be a wide-spread developer habit, some possibility to inject prompts here
- parameter description provided by the second arg of [`Annotated` special typing form](https://docs.python.org/3/library/typing.html#typing.Annotated)
- required/optional state is hinted by [`Optional` annotation](https://docs.python.org/3/library/typing.html#typing.Optional) or classic keyword args with default values
- the documented types are supported
    - `bool` -> `"boolean"`
    - `float` -> `"number"`
    - `int` -> `"integer"`
    - `str` -> `"string"`
    - `Sequence` -> `"array"`

The user expectation is:

- this is **optional**, if you want to hand craft the spec, go for it
- the generated spec is just plain JSON, you can edit it however you wish if the auto generated spec is not exactly what you need

# Example

```py
@ollama.annotated_tool
def some_tool_function(
    expr_1: t.Annotated[str, "first simple str value"],
    expr_2: t.Annotated[str, "second simple str value"],
    req_int_arg: t.Annotated[int, "a required integer"],
    req_float_arg: t.Annotated[float, "any real number"],
    req_list_arg_1: t.Annotated[list, "any builtin list"],
    req_list_arg_2: t.Annotated[t.List[t.Any], "any typed List"],
    req_enum_1: t.Annotated[ExampleEnum, "required foo bar or baz"],
    opt_arg_1: t.Annotated[t.Optional[str], "an optional string"] = None,
    opt_enum_1: t.Annotated[t.Optional[ExampleEnum], "optional foo bar or baz"] = None,
    opt_enum_2: ExampleEnum = ExampleEnum.FOO,
    opt_builtin_str_1: str = "foobar",
    opt_builtin_int_1: int = 1e6,
    opt_builtin_float_1: float = 1.0,
    opt_builtin_list_1: list = None,
):
    """a test case for Annotating a tool function's parameters.
    the docstring of the function is the Function.description."""
    return None
```

`some_tool_function.tool_schema` would provide this, usable as an item in `tools=` list

```json
{
  "type": "function",
  "function": {
    "name": "example_1",
    "description": "a test case for Annotating a tool function's parameters.\n    the docstring of the function is the Function.description.",
    "parameters": {
      "type": "object",
      "required": [
        "expr_2",
        "expr_1",
        "req_int_arg",
        "req_list_arg_2",
        "req_enum_1",
        "req_float_arg",
        "req_list_arg_1"
      ],
      "properties": {
        "expr_1": {
          "type": "string",
          "description": "first simple str value",
          "is_optional": false,
          "enum": null
        },
        "expr_2": {
          "type": "string",
          "description": "second simple str value",
          "is_optional": false,
          "enum": null
        },
        "req_int_arg": {
          "type": "integer",
          "description": "a required integer",
          "is_optional": false,
          "enum": null
        },
        "req_float_arg": {
          "type": "number",
          "description": "any real number",
          "is_optional": false,
          "enum": null
        },
        "req_list_arg_1": {
          "type": "array",
          "description": "any builtin list",
          "is_optional": false,
          "enum": null
        },
        "req_list_arg_2": {
          "type": "array",
          "description": "any typed List",
          "is_optional": false,
          "enum": null
        },
        "req_enum_1": {
          "type": "string",
          "description": "required foo bar or baz",
          "is_optional": false,
          "enum": [
            "foo",
            "bar",
            "baz"
          ]
        },
        "opt_arg_1": {
          "type": "string",
          "description": "an optional string",
          "is_optional": true,
          "enum": null
        },
        "opt_enum_1": {
          "type": "string",
          "description": "optional foo bar or baz",
          "is_optional": true,
          "enum": [
            "foo",
            "bar",
            "baz"
          ]
        },
        "opt_enum_2": {
          "type": "string",
          "description": "opt enum 2",
          "is_optional": true,
          "enum": [
            "foo",
            "bar",
            "baz"
          ]
        },
        "opt_builtin_str_1": {
          "type": "string",
          "description": "opt builtin str 1",
          "is_optional": true,
          "enum": null
        },
        "opt_builtin_int_1": {
          "type": "integer",
          "description": "opt builtin int 1",
          "is_optional": true,
          "enum": null
        },
        "opt_builtin_float_1": {
          "type": "number",
          "description": "opt builtin float 1",
          "is_optional": true,
          "enum": null
        },
        "opt_builtin_list_1": {
          "type": "array",
          "description": "opt builtin list 1",
          "is_optional": true,
          "enum": null
        }
      }
    }
  }
}
```

# Out of Scope

Not attempting to scope creep to:

- consistency with OpenAI Python SDK's similar implementation
- not using `pydantic` so to not obligate `pip install ollama` users to also install `pydantic` (see comment in https://github.com/ollama/ollama-python/pull/234#issuecomment-2253032468)
- make this a stand alone `pip install`able library, I think the implementation is deeply coupled to `ollama`'s `_types.py` implementation. I am open to doing this implementation as a separate library if the maintainers believe this syntactic sugar is out of scope.

# Related

- #234 "Add Tool Registry Feature" is highly related, however it was closed for recommendation to package as a third party library. My implementation here adds no additional dependencies and remains entirely optional.
- There was a related attempt to solve this problem: https://github.com/robocorp/llmfoo but that attempt sends the source of the function to OpenAI API to let the LLM generate the tool schema. My solution here is entirely local and relies on the Python 3 standard type utils only, 100% type reflection.