### PR TITLE
support base path. this is useful for multiple applications under one…

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1001,5 +1001,8 @@ def _parse_host(host: Optional[str]) -> str:
   split = urllib.parse.urlsplit('://'.join([scheme, hostport]))
   host = split.hostname or '127.0.0.1'
   port = split.port or port
+  path = split.path
 
-  return f'{scheme}://{host}:{port}'
+
+  return  f'{scheme}://{host}:{port}{path}'
+


### PR DESCRIPTION
Support base path. This is useful for multiple applications under one domain. With a `base_path` like `/app1/`, `/app2/`, etc., each application can have its own URL prefix, allowing clients to access them correctly.

e.g. 
```python
from ollama import Client
import httpx
httpx_auth = httpx.BasicAuth(username="ollama", password="xxxxx")
client = Client(host='https://ollama.service:32675/ollama', auth=httpx_auth)

stream = client.chat(model='llama3.1', messages=[
  {
    'role': 'user',
    'content': 'tell me a joke?',
  }], stream=True)

for chunk in stream:
  print(chunk['message']['content'], end='', flush=True)
```

The chat request will be sent to "https://ollama.service:32675/ollama/api/chat"