### PR TITLE
_stream in async client raises RuntimeError when processing HTTP errors

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -495,7 +495,7 @@ class AsyncClient(BaseClient):
         try:
           r.raise_for_status()
         except httpx.HTTPStatusError as e:
-          e.response.read()
+          await e.response.aread()
           raise ResponseError(e.response.text, e.response.status_code) from None
 
         async for line in r.aiter_lines():


### PR DESCRIPTION
When response received in AsyncClient._stream has an HTTP error, the process raises a RuntimeError("Attempted to call a sync iterator on an async stream.") due to the use of e.response.read() instead of await e.response.aread()