### PR TITLE
Added examples for vision models

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,36 @@ pip install ollama
 
 ## Usage
 
+### Text Model
 ```python
 import ollama
-response = ollama.chat(model='llama3.1', messages=[
+
+response = ollama.chat(
+  model='llama3.1', 
+  messages=[
   {
     'role': 'user',
     'content': 'Why is the sky blue?',
   },
 ])
+
+print(response['message']['content'])
+```
+
+### Vision Model
+
+```python
+import ollama
+
+response = ollama.chat(
+    model='llama3.2-vision',
+    messages=[{
+        'role': 'user',
+        'content': 'What is in this image?',
+        'images': ['path/to/image.jpg']
+    }]
+)
+
 print(response['message']['content'])
 ```
 

--- a/examples/multimodal/image_description.py
+++ b/examples/multimodal/image_description.py
@@ -1,0 +1,15 @@
+"""
+Example from ollama-python GitHub repo, extended for a vision model with system prompt, temperature setting added.
+"""
+
+import ollama
+
+llm_output = ollama.generate(
+    model="llama3.2-vision",
+    system="Answer questions with brevity and conciseness.",
+    prompt="Describe the image",
+    images=["path/to/image.jpg"],
+    options={"temperature": 0.1},
+)
+
+print(llm_output["response"])


### PR DESCRIPTION
With the introduction of llama3.2-vision recently in Ollama, it unlocks heavily desired and very useful functionality that works at a level comparable to text models. Created a example program in the examples folder and added in a vision model example under Usage in the ReadMe. Image inputs and vision models should be first class citizens moving forward! 