### PR TITLE
Bugfix/image encoding

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -97,6 +97,10 @@ class Image(BaseModel):
     if isinstance(self.value, str):
       if Path(self.value).exists():
         return b64encode(Path(self.value).read_bytes()).decode()
+
+      if self.value.split('.')[-1] in ('png', 'jpg', 'jpeg', 'webp'):
+        raise ValueError(f'File {self.value} does not exist')
+
       try:
         # Try to decode to check if it's already base64
         b64decode(self.value)

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -102,7 +102,7 @@ class Image(BaseModel):
         b64decode(self.value)
         return self.value
       except Exception:
-        return self.value
+        raise ValueError('Invalid image data, expected base64 string or path to image file') from Exception
 
 
 class GenerateRequest(BaseGenerateRequest):

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -95,12 +95,14 @@ class Image(BaseModel):
       return b64encode(self.value.read_bytes() if isinstance(self.value, Path) else self.value).decode()
 
     if isinstance(self.value, str):
+      if Path(self.value).exists():
+        return b64encode(Path(self.value).read_bytes()).decode()
       try:
         # Try to decode to check if it's already base64
         b64decode(self.value)
         return self.value
       except Exception:
-        return b64encode(Path(self.value).read_bytes()).decode() if Path(self.value).exists() else self.value
+        return self.value
 
 
 class GenerateRequest(BaseGenerateRequest):

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -1,5 +1,5 @@
 import json
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from pathlib import Path
 from datetime import datetime
 from typing import Any, Mapping, Optional, Union, Sequence
@@ -11,8 +11,6 @@ from pydantic import (
   ByteSize,
   ConfigDict,
   Field,
-  FilePath,
-  Base64Str,
   model_serializer,
 )
 
@@ -89,16 +87,20 @@ class BaseGenerateRequest(BaseStreamableRequest):
 
 
 class Image(BaseModel):
-  value: Union[FilePath, Base64Str, bytes]
+  value: Union[str, bytes, Path]
 
-  # This overloads the `model_dump` method and returns values depending on the type of the `value` field
   @model_serializer
   def serialize_model(self):
-    if isinstance(self.value, Path):
-      return b64encode(self.value.read_bytes()).decode()
-    elif isinstance(self.value, bytes):
-      return b64encode(self.value).decode()
-    return self.value
+    if isinstance(self.value, (Path, bytes)):
+      return b64encode(self.value.read_bytes() if isinstance(self.value, Path) else self.value).decode()
+
+    if isinstance(self.value, str):
+      try:
+        # Try to decode to check if it's already base64
+        b64decode(self.value)
+        return self.value
+      except Exception:
+        return b64encode(Path(self.value).read_bytes()).decode() if Path(self.value).exists() else self.value
 
 
 class GenerateRequest(BaseGenerateRequest):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,6 +180,9 @@ def test_client_generate_stream(httpserver: HTTPServer):
 
 
 def test_client_generate_images(httpserver: HTTPServer):
+  with tempfile.NamedTemporaryFile() as temp:
+    Image.new('RGB', (1, 1)).save(temp, 'PNG')
+
   httpserver.expect_ordered_request(
     '/api/generate',
     method='POST',
@@ -187,7 +190,7 @@ def test_client_generate_images(httpserver: HTTPServer):
       'model': 'dummy',
       'prompt': 'Why is the sky blue?',
       'stream': False,
-      'images': ['iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'],
+      'images': [temp.name],
     },
   ).respond_with_json(
     {
@@ -198,11 +201,9 @@ def test_client_generate_images(httpserver: HTTPServer):
 
   client = Client(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as temp:
-    Image.new('RGB', (1, 1)).save(temp, 'PNG')
-    response = client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
-    assert response['model'] == 'dummy'
-    assert response['response'] == 'Because it is.'
+  response = client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
+  assert response['model'] == 'dummy'
+  assert response['response'] == 'Because it is.'
 
 
 def test_client_pull(httpserver: HTTPServer):
@@ -655,6 +656,9 @@ async def test_async_client_generate_stream(httpserver: HTTPServer):
 
 @pytest.mark.asyncio
 async def test_async_client_generate_images(httpserver: HTTPServer):
+  with tempfile.NamedTemporaryFile() as temp:
+    Image.new('RGB', (1, 1)).save(temp, 'PNG')
+
   httpserver.expect_ordered_request(
     '/api/generate',
     method='POST',
@@ -662,7 +666,7 @@ async def test_async_client_generate_images(httpserver: HTTPServer):
       'model': 'dummy',
       'prompt': 'Why is the sky blue?',
       'stream': False,
-      'images': ['iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'],
+      'images': [temp.name],
     },
   ).respond_with_json(
     {
@@ -673,11 +677,9 @@ async def test_async_client_generate_images(httpserver: HTTPServer):
 
   client = AsyncClient(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as temp:
-    Image.new('RGB', (1, 1)).save(temp, 'PNG')
-    response = await client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
-    assert response['model'] == 'dummy'
-    assert response['response'] == 'Because it is.'
+  response = await client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
+  assert response['model'] == 'dummy'
+  assert response['response'] == 'Because it is.'
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,29 +180,27 @@ def test_client_generate_stream(httpserver: HTTPServer):
 
 
 def test_client_generate_images(httpserver: HTTPServer):
-  with tempfile.NamedTemporaryFile() as temp_file:
-    temp_file.write(b'test file content')
-    temp_file.flush()
+  httpserver.expect_ordered_request(
+    '/api/generate',
+    method='POST',
+    json={
+      'model': 'dummy',
+      'prompt': 'Why is the sky blue?',
+      'stream': False,
+      'images': ['iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'],
+    },
+  ).respond_with_json(
+    {
+      'model': 'dummy',
+      'response': 'Because it is.',
+    }
+  )
 
-    httpserver.expect_ordered_request(
-      '/api/generate',
-      method='POST',
-      json={
-        'model': 'dummy',
-        'prompt': 'Why is the sky blue?',
-        'stream': False,
-        'images': ['dGVzdCBmaWxlIGNvbnRlbnQ='],
-      },
-    ).respond_with_json(
-      {
-        'model': 'dummy',
-        'response': 'Because it is.',
-      }
-    )
+  client = Client(httpserver.url_for('/'))
 
-    client = Client(httpserver.url_for('/'))
-
-    response = client.generate('dummy', 'Why is the sky blue?', images=[temp_file.name])
+  with tempfile.NamedTemporaryFile() as temp:
+    Image.new('RGB', (1, 1)).save(temp, 'PNG')
+    response = client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
     assert response['model'] == 'dummy'
     assert response['response'] == 'Because it is.'
 
@@ -657,29 +655,27 @@ async def test_async_client_generate_stream(httpserver: HTTPServer):
 
 @pytest.mark.asyncio
 async def test_async_client_generate_images(httpserver: HTTPServer):
-  with tempfile.NamedTemporaryFile() as temp_file:
-    temp_file.write(b'test file content')
-    temp_file.flush()
+  httpserver.expect_ordered_request(
+    '/api/generate',
+    method='POST',
+    json={
+      'model': 'dummy',
+      'prompt': 'Why is the sky blue?',
+      'stream': False,
+      'images': ['iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'],
+    },
+  ).respond_with_json(
+    {
+      'model': 'dummy',
+      'response': 'Because it is.',
+    }
+  )
 
-    httpserver.expect_ordered_request(
-      '/api/generate',
-      method='POST',
-      json={
-        'model': 'dummy',
-        'prompt': 'Why is the sky blue?',
-        'stream': False,
-        'images': ['dGVzdCBmaWxlIGNvbnRlbnQ='],
-      },
-    ).respond_with_json(
-      {
-        'model': 'dummy',
-        'response': 'Because it is.',
-      }
-    )
+  client = AsyncClient(httpserver.url_for('/'))
 
-    client = AsyncClient(httpserver.url_for('/'))
-
-    response = await client.generate('dummy', 'Why is the sky blue?', images=[temp_file.name])
+  with tempfile.NamedTemporaryFile() as temp:
+    Image.new('RGB', (1, 1)).save(temp, 'PNG')
+    response = await client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
     assert response['model'] == 'dummy'
     assert response['response'] == 'Because it is.'
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,30 +180,31 @@ def test_client_generate_stream(httpserver: HTTPServer):
 
 
 def test_client_generate_images(httpserver: HTTPServer):
-  with tempfile.NamedTemporaryFile() as temp:
-    Image.new('RGB', (1, 1)).save(temp, 'PNG')
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(b'test file content')
+    temp_file.flush()
 
-  httpserver.expect_ordered_request(
-    '/api/generate',
-    method='POST',
-    json={
-      'model': 'dummy',
-      'prompt': 'Why is the sky blue?',
-      'stream': False,
-      'images': [temp.name],
-    },
-  ).respond_with_json(
-    {
-      'model': 'dummy',
-      'response': 'Because it is.',
-    }
-  )
+    httpserver.expect_ordered_request(
+      '/api/generate',
+      method='POST',
+      json={
+        'model': 'dummy',
+        'prompt': 'Why is the sky blue?',
+        'stream': False,
+        'images': ['dGVzdCBmaWxlIGNvbnRlbnQ='],
+      },
+    ).respond_with_json(
+      {
+        'model': 'dummy',
+        'response': 'Because it is.',
+      }
+    )
 
-  client = Client(httpserver.url_for('/'))
+    client = Client(httpserver.url_for('/'))
 
-  response = client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
-  assert response['model'] == 'dummy'
-  assert response['response'] == 'Because it is.'
+    response = client.generate('dummy', 'Why is the sky blue?', images=[temp_file.name])
+    assert response['model'] == 'dummy'
+    assert response['response'] == 'Because it is.'
 
 
 def test_client_pull(httpserver: HTTPServer):
@@ -656,30 +657,31 @@ async def test_async_client_generate_stream(httpserver: HTTPServer):
 
 @pytest.mark.asyncio
 async def test_async_client_generate_images(httpserver: HTTPServer):
-  with tempfile.NamedTemporaryFile() as temp:
-    Image.new('RGB', (1, 1)).save(temp, 'PNG')
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(b'test file content')
+    temp_file.flush()
 
-  httpserver.expect_ordered_request(
-    '/api/generate',
-    method='POST',
-    json={
-      'model': 'dummy',
-      'prompt': 'Why is the sky blue?',
-      'stream': False,
-      'images': [temp.name],
-    },
-  ).respond_with_json(
-    {
-      'model': 'dummy',
-      'response': 'Because it is.',
-    }
-  )
+    httpserver.expect_ordered_request(
+      '/api/generate',
+      method='POST',
+      json={
+        'model': 'dummy',
+        'prompt': 'Why is the sky blue?',
+        'stream': False,
+        'images': ['dGVzdCBmaWxlIGNvbnRlbnQ='],
+      },
+    ).respond_with_json(
+      {
+        'model': 'dummy',
+        'response': 'Because it is.',
+      }
+    )
 
-  client = AsyncClient(httpserver.url_for('/'))
+    client = AsyncClient(httpserver.url_for('/'))
 
-  response = await client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
-  assert response['model'] == 'dummy'
-  assert response['response'] == 'Because it is.'
+    response = await client.generate('dummy', 'Why is the sky blue?', images=[temp_file.name])
+    assert response['model'] == 'dummy'
+    assert response['response'] == 'Because it is.'
 
 
 @pytest.mark.asyncio

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -4,7 +4,7 @@ from base64 import b64encode
 from ollama._types import Image
 
 
-def test_image_serialization(tmp_path):
+def test_image_serialization():
   # Test bytes serialization
   image_bytes = b'test image bytes'
   img = Image(value=image_bytes)

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -10,23 +10,23 @@ def test_image_serialization(tmp_path):
   img = Image(value=image_bytes)
   assert img.model_dump() == b64encode(image_bytes).decode()
 
-  # Test Path serialization
-  test_file = tmp_path / 'test.txt'
-  test_file.write_bytes(b'test file content')
-  img = Image(value=test_file)
-  assert img.model_dump() == b64encode(test_file.read_bytes()).decode()
-
   # Test base64 string serialization
   b64_str = 'dGVzdCBiYXNlNjQgc3RyaW5n'
   img = Image(value=b64_str)
   assert img.model_dump() == b64_str  # Should return as-is if valid base64
 
-  # Test regular string path serialization
-  test_file2 = tmp_path / 'test2.txt'
-  test_file2.write_bytes(b'test file content')
-  img = Image(value=str(test_file2))
-  assert img.model_dump() == b64encode(test_file2.read_bytes()).decode()
-
   # Test regular string that's not a path
   img = Image(value='not a path or base64')
   assert img.model_dump() == 'not a path or base64'  # Should return as-is
+
+  # # Test regular string path serialization
+  # test_file2 = tmp_path / 'test2.txt'
+  # test_file2.write_bytes(b'test file content')
+  # img = Image(value=str(test_file2))
+  # assert img.model_dump() == b64encode(test_file2.read_bytes()).decode()
+
+  # # Test Path serialization
+  # test_file = tmp_path / 'test.txt'
+  # test_file.write_bytes(b'test file content')
+  # img = Image(value=test_file)
+  # assert img.model_dump() == b64encode(test_file.read_bytes()).decode()

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -4,22 +4,17 @@ from base64 import b64encode
 from ollama._types import Image
 
 
-def test_image_serialization():
+def test_image_serialization(tmp_path):
   # Test bytes serialization
   image_bytes = b'test image bytes'
   img = Image(value=image_bytes)
   assert img.model_dump() == b64encode(image_bytes).decode()
 
   # Test Path serialization
-  from pathlib import Path
-  import tempfile
-
-  with tempfile.NamedTemporaryFile() as f:
-    f.write(b'test file content')
-    f.flush()
-    path = Path(f.name)
-    img = Image(value=path)
-    assert img.model_dump() == b64encode(path.read_bytes()).decode()
+  test_file = tmp_path / 'test.txt'
+  test_file.write_bytes(b'test file content')
+  img = Image(value=test_file)
+  assert img.model_dump() == b64encode(test_file.read_bytes()).decode()
 
   # Test base64 string serialization
   b64_str = 'dGVzdCBiYXNlNjQgc3RyaW5n'
@@ -27,11 +22,10 @@ def test_image_serialization():
   assert img.model_dump() == b64_str  # Should return as-is if valid base64
 
   # Test regular string path serialization
-  with tempfile.NamedTemporaryFile() as f:
-    f.write(b'test file content')
-    f.flush()
-    img = Image(value=f.name)
-    assert img.model_dump() == b64encode(Path(f.name).read_bytes()).decode()
+  test_file2 = tmp_path / 'test2.txt'
+  test_file2.write_bytes(b'test file content')
+  img = Image(value=str(test_file2))
+  assert img.model_dump() == b64encode(test_file2.read_bytes()).decode()
 
   # Test regular string that's not a path
   img = Image(value='not a path or base64')

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -1,32 +1,38 @@
 from base64 import b64encode
-
-
+from pathlib import Path
 from ollama._types import Image
+import tempfile
 
 
-def test_image_serialization():
-  # Test bytes serialization
+def test_image_serialization_bytes():
   image_bytes = b'test image bytes'
+  encoded_string = b64encode(image_bytes).decode()
   img = Image(value=image_bytes)
-  assert img.model_dump() == b64encode(image_bytes).decode()
+  assert img.model_dump() == encoded_string
 
-  # Test base64 string serialization
+
+def test_image_serialization_base64_string():
   b64_str = 'dGVzdCBiYXNlNjQgc3RyaW5n'
   img = Image(value=b64_str)
   assert img.model_dump() == b64_str  # Should return as-is if valid base64
 
-  # Test regular string that's not a path
+
+def test_image_serialization_plain_string():
   img = Image(value='not a path or base64')
   assert img.model_dump() == 'not a path or base64'  # Should return as-is
 
-  # # Test regular string path serialization
-  # test_file2 = tmp_path / 'test2.txt'
-  # test_file2.write_bytes(b'test file content')
-  # img = Image(value=str(test_file2))
-  # assert img.model_dump() == b64encode(test_file2.read_bytes()).decode()
 
-  # # Test Path serialization
-  # test_file = tmp_path / 'test.txt'
-  # test_file.write_bytes(b'test file content')
-  # img = Image(value=test_file)
-  # assert img.model_dump() == b64encode(test_file.read_bytes()).decode()
+def test_image_serialization_path():
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(b'test file content')
+    temp_file.flush()
+    img = Image(value=Path(temp_file.name))
+    assert img.model_dump() == b64encode(b'test file content').decode()
+
+
+def test_image_serialization_string_path():
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(b'test file content')
+    temp_file.flush()
+    img = Image(value=temp_file.name)
+    assert img.model_dump() == b64encode(b'test file content').decode()

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -1,4 +1,4 @@
-from base64 import b64decode, b64encode
+from base64 import b64encode
 
 
 from ollama._types import Image
@@ -10,7 +10,29 @@ def test_image_serialization():
   img = Image(value=image_bytes)
   assert img.model_dump() == b64encode(image_bytes).decode()
 
+  # Test Path serialization
+  from pathlib import Path
+  import tempfile
+
+  with tempfile.NamedTemporaryFile() as f:
+    f.write(b'test file content')
+    f.flush()
+    path = Path(f.name)
+    img = Image(value=path)
+    assert img.model_dump() == b64encode(path.read_bytes()).decode()
+
   # Test base64 string serialization
   b64_str = 'dGVzdCBiYXNlNjQgc3RyaW5n'
   img = Image(value=b64_str)
-  assert img.model_dump() == b64decode(b64_str).decode()
+  assert img.model_dump() == b64_str  # Should return as-is if valid base64
+
+  # Test regular string path serialization
+  with tempfile.NamedTemporaryFile() as f:
+    f.write(b'test file content')
+    f.flush()
+    img = Image(value=f.name)
+    assert img.model_dump() == b64encode(Path(f.name).read_bytes()).decode()
+
+  # Test regular string that's not a path
+  img = Image(value='not a path or base64')
+  assert img.model_dump() == 'not a path or base64'  # Should return as-is

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -40,5 +40,9 @@ def test_image_serialization_string_path():
     assert img.model_dump() == b64encode(b'test file content').decode()
 
   with pytest.raises(ValueError):
-    img = Image(value='Error')
+    img = Image(value='some_path/that/does/not/exist.png')
+    img.model_dump()
+
+  with pytest.raises(ValueError):
+    img = Image(value='not an image')
     img.model_dump()

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -1,5 +1,7 @@
 from base64 import b64encode
 from pathlib import Path
+
+import pytest
 from ollama._types import Image
 import tempfile
 
@@ -36,3 +38,7 @@ def test_image_serialization_string_path():
     temp_file.flush()
     img = Image(value=temp_file.name)
     assert img.model_dump() == b64encode(b'test file content').decode()
+
+  with pytest.raises(ValueError):
+    img = Image(value='Error')
+    img.model_dump()


### PR DESCRIPTION
Images are not being encoded correctly given a b64 string - it tries to encode it twice.

Updated the types for Image as well as the serialization to better handle these cases - added tests as well