### PR TITLE
Disable tests for READMEs and examples

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: test
 
 on:
   pull_request:
+    paths:
+      - 'examples/**'
+      - '**/README.md'
 
 jobs:
   test:


### PR DESCRIPTION
We should stop running tests for readme and test updates