### PR TITLE
make subscription methods more consistent with `__contains__`

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -93,6 +93,9 @@ class SubscriptableBaseModel(BaseModel):
     >>> msg = Message(role='user')
     >>> msg.get('nonexistent', 'default')
     'default'
+    >>> msg = Message(role='user', tool_calls=[ Message.ToolCall(function=Message.ToolCall.Function(name='foo', arguments={}))])
+    >>> msg.get('tool_calls')[0]['function']['name']
+    'foo'
     """
     return self[key] if key in self else default
 

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -88,9 +88,6 @@ class SubscriptableBaseModel(BaseModel):
     >>> msg = Message(role='user')
     >>> msg.get('role')
     'user'
-    >>> tool = Tool()
-    >>> tool.get('type')
-    'function'
     >>> msg = Message(role='user')
     >>> msg.get('nonexistent')
     >>> msg = Message(role='user')

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -17,9 +17,30 @@ from pydantic import (
 
 class SubscriptableBaseModel(BaseModel):
   def __getitem__(self, key: str) -> Any:
-    return getattr(self, key)
+    """
+    >>> msg = Message(role='user')
+    >>> msg['role']
+    'user'
+    >>> tool = Tool()
+    >>> tool['type']
+    'function'
+    >>> msg = Message(role='user')
+    >>> msg['nonexistent']
+    Traceback (most recent call last):
+    KeyError: 'nonexistent'
+    """
+    if key in self:
+      return getattr(self, key)
+
+    raise KeyError(key)
 
   def __setitem__(self, key: str, value: Any) -> None:
+    """
+    >>> msg = Message(role='user')
+    >>> msg['role'] = 'assistant'
+    >>> msg['role']
+    'assistant'
+    """
     setattr(self, key, value)
 
   def __contains__(self, key: str) -> bool:
@@ -61,7 +82,20 @@ class SubscriptableBaseModel(BaseModel):
     return False
 
   def get(self, key: str, default: Any = None) -> Any:
-    return getattr(self, key, default)
+    """
+    >>> msg = Message(role='user')
+    >>> msg.get('role')
+    'user'
+    >>> tool = Tool()
+    >>> tool.get('type')
+    'function'
+    >>> msg = Message(role='user')
+    >>> msg.get('nonexistent')
+    >>> msg = Message(role='user')
+    >>> msg.get('nonexistent', 'default')
+    'default'
+    """
+    return self[key] if key in self else default
 
 
 class Options(SubscriptableBaseModel):

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -21,9 +21,6 @@ class SubscriptableBaseModel(BaseModel):
     >>> msg = Message(role='user')
     >>> msg['role']
     'user'
-    >>> tool = Tool()
-    >>> tool['type']
-    'function'
     >>> msg = Message(role='user')
     >>> msg['nonexistent']
     Traceback (most recent call last):

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -40,6 +40,11 @@ class SubscriptableBaseModel(BaseModel):
     >>> msg['role'] = 'assistant'
     >>> msg['role']
     'assistant'
+    >>> tool_call = Message.ToolCall(function=Message.ToolCall.Function(name='foo', arguments={}))
+    >>> msg = Message(role='user', content='hello')
+    >>> msg['tool_calls'] = [tool_call]
+    >>> msg['tool_calls'][0]['function']['name']
+    'foo'
     """
     setattr(self, key, value)
 


### PR DESCRIPTION
`message["tool_calls"]` will now raise an exception if it's not set to be consistent with the old map behavior and the `__contains__` operation updated in 0.4.1