### PR TITLE
Change proposed in example/chat-with-history.py to overcome runtime error.

### DIFF
--- a/examples/chat-with-history.py
+++ b/examples/chat-with-history.py
@@ -31,8 +31,8 @@ while True:
   )
 
   # Add the response to the messages to maintain the history
-  messages.append(
-    {'role': 'user', 'content': user_input},
-    {'role': 'assistant', 'content': response.message.content},
+  messages.extend(
+        [{'role': 'user', 'content': user_input},
+         {'role': 'assistant', 'content': response.message.content}]
   )
   print(response.message.content + '\n')

--- a/examples/chat-with-history.py
+++ b/examples/chat-with-history.py
@@ -31,8 +31,8 @@ while True:
   )
 
   # Add the response to the messages to maintain the history
-  messages.extend(
-        [{'role': 'user', 'content': user_input},
-         {'role': 'assistant', 'content': response.message.content}]
-  )
+  messages += [
+    {'role': 'user', 'content': user_input},
+    {'role': 'assistant', 'content': response.message.content},
+  ]
   print(response.message.content + '\n')


### PR DESCRIPTION
append() method accepts only 1 argument. We can use extend() method as an alternative.