### PR TITLE
fix: address pydantic validation errors during ollama LLM invoke requests

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -151,7 +151,7 @@ class BaseGenerateRequest(BaseStreamableRequest):
   options: Optional[Union[Mapping[str, Any], Options]] = None
   'Options to use for the request.'
 
-  format: Optional[Union[Literal['json'], JsonSchemaValue]] = None
+  format: Optional[Union[Literal['', 'json'], JsonSchemaValue]] = None
   'Format of the response.'
 
   keep_alive: Optional[Union[float, str]] = None


### PR DESCRIPTION
This PR resolves a pydantic validation issue encountered when invoking Ollama’s LLM generation requests, and addresses issue #366 

This PR resolves a pydantic validation issue encountered when invoking Ollama’s LLM generation requests. Previously, the format field for GenerateRequest strictly required a literal value of 'json'. When the format field was omitted or passed as an empty string, Pydantic validation failed, producing errors similar to the following:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for GenerateRequest
format.literal['json']
  Input should be 'json' [type=literal_error, input_value='', input_type=str]
  
format.dict[str,any]
  Input should be a valid dictionary [type=dict_type, input_value='', input_type=str]
```

By expanding the format union type to include both the empty string '' and 'json' values, the request validation now passes even when format is not explicitly defined or is empty. This change ensures that developers have more flexibility in specifying their request parameters and that the underlying validation does not fail in cases where format is absent or intentionally left blank.

### Key Changes:
* Updated the format field from Optional[Union[Literal['json'], JsonSchemaValue]] to Optional[Union[Literal['', 'json'], JsonSchemaValue]].
* Ensured that requests with an empty format do not cause validation errors.
