### PR TITLE
test against real Ollama running in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,3 +34,24 @@ jobs:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
         if: ${{ always() }}
+
+  test-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: poetry
+
+      - run: poetry install --with=dev
+
+      - uses: pydantic/ollama-action@v3
+        with:
+          model: qwen2:0.5b
+
+      - run: poetry run pytest tests/test_live.py -v --durations=100
+        env:
+          OLLAMA_TEST_LIVE: "1"

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -8,46 +8,46 @@ from pydantic import BaseModel
 from ollama import AsyncClient
 
 pytestmark = [
-    pytest.mark.skipif(not os.getenv('OLLAMA_TEST_LIVE'), reason='live tests disabled'),
-    pytest.mark.asyncio,
+  pytest.mark.skipif(not os.getenv('OLLAMA_TEST_LIVE'), reason='live tests disabled'),
+  pytest.mark.asyncio,
 ]
 
 
 async def test_text():
-    client = AsyncClient()
-    response = await client.chat(
-        'qwen2:0.5b',
-        messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
-        options={'temperature': 0},
-    )
-    print('Text response:', response)
-    assert 'paris' in response.message.content.lower()
+  client = AsyncClient()
+  response = await client.chat(
+    'qwen2:0.5b',
+    messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
+    options={'temperature': 0},
+  )
+  print('Text response:', response)
+  assert 'paris' in response.message.content.lower()
 
 
 async def test_stream():
-    client = AsyncClient()
-    stream = await client.chat(
-        'qwen2:0.5b',
-        messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
-        options={'temperature': 0},
-        stream=True,
-    )
-    text = ''.join([part['message']['content'] async for part in stream])
-    print('Text response:', text)
-    assert 'paris' in text.lower()
+  client = AsyncClient()
+  stream = await client.chat(
+    'qwen2:0.5b',
+    messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
+    options={'temperature': 0},
+    stream=True,
+  )
+  text = ''.join([part['message']['content'] async for part in stream])
+  print('Text response:', text)
+  assert 'paris' in text.lower()
 
 
 class MyModel(BaseModel):
-    city: str
+  city: str
 
 
 async def test_structured():
-    client = AsyncClient()
-    response = await client.chat(
-        'qwen2:0.5b',
-        messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
-        format=MyModel.model_json_schema(),
-        options={'temperature': 0},
-    )
-    my_model = MyModel.model_validate_json(response.message.content)
-    assert my_model.city.lower() == 'paris'
+  client = AsyncClient()
+  response = await client.chat(
+    'qwen2:0.5b',
+    messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
+    format=MyModel.model_json_schema(),
+    options={'temperature': 0},
+  )
+  my_model = MyModel.model_validate_json(response.message.content)
+  assert my_model.city.lower() == 'paris'

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,53 @@
+"""Tests of making requests to a live Ollama server running locally"""
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from ollama import AsyncClient
+
+pytestmark = [
+    pytest.mark.skipif(not os.getenv('OLLAMA_TEST_LIVE'), reason='live tests disabled'),
+    pytest.mark.asyncio,
+]
+
+
+async def test_text():
+    client = AsyncClient()
+    response = await client.chat(
+        'qwen2:0.5b',
+        messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
+        options={'temperature': 0},
+    )
+    print('Text response:', response)
+    assert 'paris' in response.message.content.lower()
+
+
+async def test_stream():
+    client = AsyncClient()
+    stream = await client.chat(
+        'qwen2:0.5b',
+        messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
+        options={'temperature': 0},
+        stream=True,
+    )
+    text = ''.join([part['message']['content'] async for part in stream])
+    print('Text response:', text)
+    assert 'paris' in text.lower()
+
+
+class MyModel(BaseModel):
+    city: str
+
+
+async def test_structured():
+    client = AsyncClient()
+    response = await client.chat(
+        'qwen2:0.5b',
+        messages=[{'role': 'user', 'content': 'What is the capital of France?'}],
+        format=MyModel.model_json_schema(),
+        options={'temperature': 0},
+    )
+    my_model = MyModel.model_validate_json(response.message.content)
+    assert my_model.city.lower() == 'paris'


### PR DESCRIPTION
Uses [`ollama-action`](https://github.com/pydantic/ollama-action) which I built for [`pydantic-ai`](https://github.com/pydantic/pydantic-ai) - happy to transfer `ollama-action` to the `ollama` organization if you'd like.

By the way, can I **STRONGLY** encourage you to move the codebase to use 4 spaces for indents, not 2:

4 spaces is the default and almost ubiquitous in Python ecosystem, the switch should be a matter of just configuring ruff and running it.

Using 2 spaces (trivial though it may seem) will put off any experienced Python developer from contributing - exactly the people I guess you want to contribute.