### PR TITLE
Gracefully handle httpx.ConnectError from Client and AsyncClient

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -115,11 +115,13 @@ class Client(BaseClient):
     super().__init__(httpx.Client, host, **kwargs)
 
   def _request_raw(self, *args, **kwargs):
-    r = self._client.request(*args, **kwargs)
     try:
+      r = self._client.request(*args, **kwargs)
       r.raise_for_status()
     except httpx.HTTPStatusError as e:
       raise ResponseError(e.response.text, e.response.status_code) from None
+    except httpx.ConnectError:
+      raise ResponseError("error connecting to ollama server: have you checked that it's running?", 500)
     return r
 
   @overload
@@ -617,11 +619,14 @@ class AsyncClient(BaseClient):
     super().__init__(httpx.AsyncClient, host, **kwargs)
 
   async def _request_raw(self, *args, **kwargs):
-    r = await self._client.request(*args, **kwargs)
     try:
+      r = await self._client.request(*args, **kwargs)
       r.raise_for_status()
     except httpx.HTTPStatusError as e:
       raise ResponseError(e.response.text, e.response.status_code) from None
+    except httpx.ConnectError:
+      raise ResponseError("error connecting to ollama server: have you checked that it's running?", 500)
+
     return r
 
   @overload


### PR DESCRIPTION
Log a more understandable and actionable error when we encounter the `httpx.ConnectError`

fixes #304
