### PR TITLE
fix: export Image model

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -2,6 +2,7 @@ from ollama._client import Client, AsyncClient
 from ollama._types import (
   Options,
   Message,
+  Image,
   Tool,
   GenerateResponse,
   ChatResponse,
@@ -21,6 +22,7 @@ __all__ = [
   'AsyncClient',
   'Options',
   'Message',
+  'Image',
   'Tool',
   'GenerateResponse',
   'ChatResponse',


### PR DESCRIPTION
Allows construction of `Message(..., images=Image(value=...))` without having to import from `._types`.

Note that using `Image()` currently fails serialization due to a different bug (see #386).