### PR TITLE
fix: don't run lints on all Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,17 +20,27 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
       - run: poetry install --with=dev
+      - run: poetry run pytest . --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=ollama --cov-report=xml --cov-report=html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+        if: ${{ always() }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: poetry
+      - run: poetry install --with=dev
       - run: poetry run ruff check --output-format=github .
       - run: poetry run ruff format --check .
-      - run: poetry run pytest . --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=ollama --cov-report=xml --cov-report=html
       - name: check poetry.lock is up-to-date
         run: poetry check --lock
       - name: check requirements.txt is up-to-date
         run: |
           poetry export >requirements.txt
           git diff --exit-code requirements.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results-${{ matrix.python-version }}
-          path: junit/test-results-${{ matrix.python-version }}.xml
-        if: ${{ always() }}


### PR DESCRIPTION
No need to spend time running the same lints 6 times.