### PR TITLE
remove sha256 as it's already available in the digest

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -554,7 +554,7 @@ class Client(BaseClient):
     digest = f'sha256:{sha256sum.hexdigest()}'
 
     with open(path, 'rb') as r:
-      self._request_raw('POST', f'/api/blobs/sha256:{digest}', content=r)
+      self._request_raw('POST', f'/api/blobs/{digest}', content=r)
 
     return digest
 


### PR DESCRIPTION
`sha256:` isn't necessary as it's already available in the digest.