### PR TITLE
Remove upper bound from Python version specifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -638,5 +638,5 @@ watchdog = ["watchdog (>=2.3)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.8"
-content-hash = "ff70c562172e38058111703d8219e18a0ed367e8e3ff647d7eff457d3bf3204e"
+python-versions = ">=3.8"
+content-hash = "944ba22055cb6bcd3201871a4ccd5289e2fa92f258b32d0fa527ab8a7af1fee9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage = "https://ollama.com"
 repository = "https://github.com/ollama/ollama-python"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8"
 httpx = ">=0.27,<0.29"
 pydantic = "^2.9.0"
 


### PR DESCRIPTION
Capping the Python version (e.g. `<4`) is a bad practice.

* https://github.com/pypa/packaging.python.org/pull/850
* https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
* https://discuss.python.org/t/requires-python-upper-limits/12663

Hence, I've removed the upper bound, i.e. I've replaced the version specifier `^` by `>=`.