### PR TITLE
types: enable passing messages with arbitrary role

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -256,7 +256,7 @@ class Message(SubscriptableBaseModel):
   Chat message.
   """
 
-  role: Literal['user', 'assistant', 'system', 'tool']
+  role: Literal['user', 'assistant', 'system', 'tool', 'control']
   "Assumed role of the message. Response messages has role 'assistant' or 'tool'."
 
   content: Optional[str] = None

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -256,7 +256,7 @@ class Message(SubscriptableBaseModel):
   Chat message.
   """
 
-  role: Literal['user', 'assistant', 'system', 'tool', 'control']
+  role: Literal['user', 'assistant', 'system', 'tool', 'control', 'document']
   "Assumed role of the message. Response messages has role 'assistant' or 'tool'."
 
   content: Optional[str] = None

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -256,7 +256,7 @@ class Message(SubscriptableBaseModel):
   Chat message.
   """
 
-  role: Literal['user', 'assistant', 'system', 'tool', 'control', 'document']
+  role: str
   "Assumed role of the message. Response messages has role 'assistant' or 'tool'."
 
   content: Optional[str] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,11 @@
 import base64
+from httpx import Response as httpxResponse
 import json
 import os
 import re
-import tempfile
 from pathlib import Path
+import tempfile
+from typing import Any, AsyncIterator
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -11,7 +13,7 @@ from pytest_httpserver import HTTPServer, URIPattern
 from werkzeug.wrappers import Request, Response
 
 from ollama._client import CONNECTION_ERROR_MESSAGE, AsyncClient, Client, _copy_tools
-from ollama._types import Image
+from ollama._types import Image, Message
 
 PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'
 PNG_BYTES = base64.b64decode(PNG_BASE64)
@@ -1181,3 +1183,38 @@ async def test_async_client_connection_error():
   with pytest.raises(ConnectionError) as exc_info:
     await client.show('model')
   assert str(exc_info.value) == 'Failed to connect to Ollama. Please check that Ollama is downloaded, running and accessible. https://ollama.com/download'
+
+def test_arbitrary_roles_accepted_in_message():
+  _ = Message(role="somerandomrole", content="I'm ok with you adding any role message now!")
+
+def _mock_request(*args: Any, **kwargs: Any) -> Response:
+    return httpxResponse(status_code=200, content="{'response': 'Hello world!'}")
+
+def test_arbitrary_roles_accepted_in_message_request(monkeypatch:pytest.MonkeyPatch):
+
+  monkeypatch.setattr(Client, "_request", _mock_request)
+
+  client = Client()
+
+  client.chat(model="llama3.1",
+              messages=[
+                {"role":"somerandomrole","content":"I'm ok with you adding any role message now!"},
+                {"role":"user","content":"Hello world!"}
+              ])
+  
+async def _mock_request_async(*args: Any, **kwargs: Any) -> Response:
+    return httpxResponse(status_code=200, content="{'response': 'Hello world!'}")
+
+@pytest.mark.asyncio
+async def test_arbitrary_roles_accepted_in_message_request_async(monkeypatch:pytest.MonkeyPatch):
+
+  monkeypatch.setattr(AsyncClient, "_request", _mock_request_async)
+
+  client = AsyncClient()
+
+  await client.chat(model="llama3.1",
+              messages=[
+                {"role":"somerandomrole","content":"I'm ok with you adding any role message now!"},
+                {"role":"user","content":"Hello world!"}
+              ])
+  

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1184,37 +1184,31 @@ async def test_async_client_connection_error():
     await client.show('model')
   assert str(exc_info.value) == 'Failed to connect to Ollama. Please check that Ollama is downloaded, running and accessible. https://ollama.com/download'
 
+
 def test_arbitrary_roles_accepted_in_message():
-  _ = Message(role="somerandomrole", content="I'm ok with you adding any role message now!")
+  _ = Message(role='somerandomrole', content="I'm ok with you adding any role message now!")
+
 
 def _mock_request(*args: Any, **kwargs: Any) -> Response:
-    return httpxResponse(status_code=200, content="{'response': 'Hello world!'}")
+  return httpxResponse(status_code=200, content="{'response': 'Hello world!'}")
 
-def test_arbitrary_roles_accepted_in_message_request(monkeypatch:pytest.MonkeyPatch):
 
-  monkeypatch.setattr(Client, "_request", _mock_request)
+def test_arbitrary_roles_accepted_in_message_request(monkeypatch: pytest.MonkeyPatch):
+  monkeypatch.setattr(Client, '_request', _mock_request)
 
   client = Client()
 
-  client.chat(model="llama3.1",
-              messages=[
-                {"role":"somerandomrole","content":"I'm ok with you adding any role message now!"},
-                {"role":"user","content":"Hello world!"}
-              ])
-  
+  client.chat(model='llama3.1', messages=[{'role': 'somerandomrole', 'content': "I'm ok with you adding any role message now!"}, {'role': 'user', 'content': 'Hello world!'}])
+
+
 async def _mock_request_async(*args: Any, **kwargs: Any) -> Response:
-    return httpxResponse(status_code=200, content="{'response': 'Hello world!'}")
+  return httpxResponse(status_code=200, content="{'response': 'Hello world!'}")
+
 
 @pytest.mark.asyncio
-async def test_arbitrary_roles_accepted_in_message_request_async(monkeypatch:pytest.MonkeyPatch):
-
-  monkeypatch.setattr(AsyncClient, "_request", _mock_request_async)
+async def test_arbitrary_roles_accepted_in_message_request_async(monkeypatch: pytest.MonkeyPatch):
+  monkeypatch.setattr(AsyncClient, '_request', _mock_request_async)
 
   client = AsyncClient()
 
-  await client.chat(model="llama3.1",
-              messages=[
-                {"role":"somerandomrole","content":"I'm ok with you adding any role message now!"},
-                {"role":"user","content":"Hello world!"}
-              ])
-  
+  await client.chat(model='llama3.1', messages=[{'role': 'somerandomrole', 'content': "I'm ok with you adding any role message now!"}, {'role': 'user', 'content': 'Hello world!'}])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,13 @@
 import base64
-from httpx import Response as httpxResponse
 import json
 import os
 import re
-from pathlib import Path
 import tempfile
-from typing import Any, AsyncIterator
+from pathlib import Path
+from typing import Any
 
 import pytest
+from httpx import Response as httpxResponse
 from pydantic import BaseModel, ValidationError
 from pytest_httpserver import HTTPServer, URIPattern
 from werkzeug.wrappers import Request, Response


### PR DESCRIPTION
Ollama's python client currently only permits messages with roles of either 'user', 'assistant', 'system', or 'tool'.

As described here - https://github.com/ollama/ollama/issues/8955#issuecomment-2701595820 - this prevents sending messages with the "control" role, which was introduced by IBM's granite3.2 to enable turning the "thinking" functionality on and off as needed.

This pull request adds "control" to the list of valid values for a message's "role" field/attribute so that these messages can be passed through to ollama.

Note: ollama server already handles messages with this role appropriately, but the python client currently does not allow sending them to ollama server. This resolves the issue in the python client.