### PR TITLE
feat: introduce models_list function and usage in list.py for simpler model retrieval

### DIFF
--- a/examples/list.py
+++ b/examples/list.py
@@ -1,5 +1,4 @@
-from ollama import ListResponse, list
-
+from ollama import ListResponse, list, models_list
 response: ListResponse = list()
 
 for model in response.models:
@@ -11,3 +10,8 @@ for model in response.models:
     print('  Parameter Size:', model.details.parameter_size)
     print('  Quantization Level:', model.details.quantization_level)
   print('\n')
+
+models = models_list()
+
+for name in models:
+    print(name)

--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -48,6 +48,7 @@ push = _client.push
 create = _client.create
 delete = _client.delete
 list = _client.list
+models_list = _client.models_list
 copy = _client.copy
 show = _client.show
 ps = _client.ps

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -569,6 +569,11 @@ class Client(BaseClient):
       'GET',
       '/api/tags',
     )
+  
+  def models_list(self) -> List[str]:
+    response = self.list()
+    model_names = [m.model for m in response.models]
+    return model_names
 
   def delete(self, model: str) -> StatusResponse:
     r = self._request_raw(


### PR DESCRIPTION
This pull request introduces the `models_list` function within `_client.py` and showcases its usage in `example/list.py`. The function retrieves a list of model names as strings, making it easy to display the available models.

**Key Changes**
- Created `models_list` in `_client.py` to call the existing list endpoint and isolate model names.
- Updated example/list.py` to demonstrate the use of  `models_list`.

**To Do**
- [ ] Add unit tests