### PR TITLE
Add OLLAMA_HOST blurb to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The Ollama Python library provides the easiest way to integrate Python 3.8+ proj
 - Pull a model to use with the library: `ollama pull <model>` e.g. `ollama pull llama3.2`
   - See [Ollama.com](https://ollama.com/search) for more information on the models available.
 
+The library connects to Ollama running on `http://localhost:11434` by default.
+You can change this address by setting the `OLLAMA_HOST` environment variable.
+Refer to the [FAQs](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-do-i-configure-ollama-server) for how to set environment variables on your platform.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
Without this it's opaque that the library is making HTTP requests, or to where it might be making them.

The only place I could find how to change the localhost:11434 behavior was in the Ollama FAQs.
If there is a way to set it besides OLLAMA_HOST I would love to know!