### PR TITLE
Fix the code request exception when OLLAMA_HOST=0.0.0.0

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1228,6 +1228,8 @@ def _parse_host(host: Optional[str]) -> str:
   split = urllib.parse.urlsplit('://'.join([scheme, hostport]))
   host = split.hostname or '127.0.0.1'
   port = split.port or port
+  if host == '0.0.0.0':
+    host = '127.0.0.1'
 
   try:
     if isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address):


### PR DESCRIPTION
   I have been following ollma. When ollma launched the ollama-python project last year, I immediately started to use it for testing. Unfortunately, an error occurred at that time,because according to the description on https://github.com/ollama/ollama/blob/main/docs/faq.md, OLLAMA_HOST=0.0.0.0:11434, but ollama-python does not work by default. 
       After debugging, I found that os.environ['OLLAMA_HOST'] = 'http://127.0.0.1:11434' is required. If this configuration is used in every project, the code seems a bit redundant. Later, I also communicated with some people about this issue（issue #450、issue #455、issue #407）. 
      Today I found that this problem still exists. Oh my God, so many people have encountered this problem, which means it is a common problem. I think we should avoid it.