### PR TITLE
fix: 502 gateway error

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -102,6 +102,8 @@ class BaseClient:
           'User-Agent': f'ollama-python/{__version__} ({platform.machine()} {platform.system().lower()}) Python/{platform.python_version()}',
         }.items()
       },
+      http2=False,
+      transport=httpx.HTTPTransport(retries=3),
       **kwargs,
     )
 


### PR DESCRIPTION
Disables HTTP/2 and forces the client to use HTTP/1.1.
Some servers (especially custom/local deployments like Ollama) might not fully support or handle HTTP/2 properly, which can cause unexpected issues.

configures the underlying HTTP transport to retry failed requests up to 3 times.
This is helpful for flaky local servers, slow responses, or temporary network hiccups.
httpx by default does not retry, so this can make your client more resilient.