### PR TITLE
Visualization for the ollama-python codebase

### DIFF
--- a/.codeboarding/API_Client_Core.md
+++ b/.codeboarding/API_Client_Core.md
@@ -1,0 +1,131 @@
+```mermaid
+
+graph LR
+
+    API_Client_Core["API Client Core"]
+
+    Synchronous_HTTP_Client["Synchronous HTTP Client"]
+
+    Asynchronous_HTTP_Client["Asynchronous HTTP Client"]
+
+    API_Error_Handling["API Error Handling"]
+
+    API_Client_Core -- "Delegates To" --> Synchronous_HTTP_Client
+
+    API_Client_Core -- "Manages" --> Synchronous_HTTP_Client
+
+    API_Client_Core -- "Delegates To" --> Asynchronous_HTTP_Client
+
+    API_Client_Core -- "Manages" --> Asynchronous_HTTP_Client
+
+    API_Client_Core -- "Consumes" --> API_Error_Handling
+
+    Synchronous_HTTP_Client -- "Raises" --> API_Error_Handling
+
+    Synchronous_HTTP_Client -- "Handles" --> API_Error_Handling
+
+    Asynchronous_HTTP_Client -- "Raises" --> API_Error_Handling
+
+    Asynchronous_HTTP_Client -- "Handles" --> API_Error_Handling
+
+    click API_Client_Core href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//API_Client_Core.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem provides the core functionality for interacting with the Ollama API, offering both synchronous and asynchronous interfaces, robust error handling, and foundational HTTP communication.
+
+
+
+### API Client Core
+
+This component serves as the primary entry point for users, providing both synchronous (`Client`) and asynchronous (`AsyncClient`) interfaces to interact with the Ollama API. It encapsulates the foundational setup, including host URL parsing, HTTP client initialization (`httpx`), and default configurations (headers, timeouts). It acts as the orchestrator, exposing high-level methods that delegate to specific API functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L73-L107" target="_blank" rel="noopener noreferrer">`ollama._client.BaseClient` (73:107)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L113-L622" target="_blank" rel="noopener noreferrer">`ollama._client.Client` (113:622)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L625-L1142" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient` (625:1142)</a>
+
+
+
+
+
+### Synchronous HTTP Client
+
+This component provides the functionality for making synchronous HTTP requests to the Ollama API. It handles the low-level network communication, request preparation, and initial error detection for blocking operations. It is a specialized part of the `API Client Core`, specifically implemented within the `Client` class.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L117-L125" target="_blank" rel="noopener noreferrer">`ollama._client.Client._request_raw` (117:125)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L128-L134" target="_blank" rel="noopener noreferrer">`ollama._client.Client._request` (128:134)</a>
+
+
+
+
+
+### Asynchronous HTTP Client
+
+This component mirrors the Synchronous HTTP Client but is designed for non-blocking, asynchronous operations. It enables concurrent communication with the Ollama API, which is essential for applications requiring high performance or integration into asynchronous frameworks. It is a specialized part of the `API Client Core`, specifically implemented within the `AsyncClient` class.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L629-L637" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient._request_raw` (629:637)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L640-L646" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient._request` (640:646)</a>
+
+
+
+
+
+### API Error Handling
+
+This component defines a custom exception class (`ResponseError`) specifically for errors returned by the Ollama API. It standardizes how API-specific errors are represented, providing details like the error message and HTTP status code. This ensures consistent and user-friendly error management across both synchronous and asynchronous client interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L547-L566" target="_blank" rel="noopener noreferrer">`ollama._types.ResponseError` (547:566)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Transformation_Utilities.md
+++ b/.codeboarding/Data_Transformation_Utilities.md
@@ -1,0 +1,83 @@
+```mermaid
+
+graph LR
+
+    Data_Transformation_Utilities["Data Transformation Utilities"]
+
+    Data_Type_Definitions["Data Type Definitions"]
+
+    Data_Transformation_Utilities -- "uses" --> Data_Type_Definitions
+
+    click Data_Transformation_Utilities href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//Data_Transformation_Utilities.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This analysis focuses on two fundamental components within the `ollama-python` library: `Data Transformation Utilities` and `Data Type Definitions`. These components are crucial for ensuring that data is correctly structured, validated, and exchanged within the library and with the Ollama API.
+
+
+
+### Data Transformation Utilities
+
+This component provides a set of helper functions responsible for transforming and preparing various complex data types (such as images, message lists, and Python functions) into the specific formats required by the Ollama API. It abstracts away the complexities of data formatting, ensuring that data is correctly structured and encoded before being sent in API requests. This component is fundamental because it acts as an essential intermediary, translating diverse user inputs into the standardized data models expected by the Ollama API, thereby simplifying client-side interactions and preventing data inconsistencies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1145-L1147" target="_blank" rel="noopener noreferrer">`ollama._client._copy_images` (1145:1147)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1150-L1154" target="_blank" rel="noopener noreferrer">`ollama._client._copy_messages` (1150:1154)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1157-L1159" target="_blank" rel="noopener noreferrer">`ollama._client._copy_tools` (1157:1159)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_utils.py#L55-L88" target="_blank" rel="noopener noreferrer">`ollama._utils.convert_function_to_tool` (55:88)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_utils.py#L12-L52" target="_blank" rel="noopener noreferrer">`ollama._utils._parse_docstring` (12:52)</a>
+
+
+
+
+
+### Data Type Definitions
+
+This foundational component defines the canonical data structures and models used across the `ollama-python` library. These types (e.g., `Image`, `Tool`, `Tool.Function`, and `Tool.Function.Parameters`) are primarily Pydantic models that enforce data consistency, facilitate clear communication with the Ollama API, and serve as the common language for data exchange within the library. This component is fundamental as it establishes the schema and validation rules for all data, ensuring type safety, predictable data structures, and robust error handling throughout the system.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L160-L185" target="_blank" rel="noopener noreferrer">`ollama._types.Image` (160:185)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L311-L337" target="_blank" rel="noopener noreferrer">`ollama._types.Tool` (311:337)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L314-L335" target="_blank" rel="noopener noreferrer">`ollama._types.Tool.Function` (314:335)</a>
+
+- `ollama._types.Tool.Function.Parameters` (0:0)
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L260-L308" target="_blank" rel="noopener noreferrer">`ollama._types.Message` (260:308)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/HTTP_Communication_Layer.md
+++ b/.codeboarding/HTTP_Communication_Layer.md
@@ -1,0 +1,185 @@
+```mermaid
+
+graph LR
+
+    BaseClient["BaseClient"]
+
+    Client["Client"]
+
+    AsyncClient["AsyncClient"]
+
+    OllamaTypes["OllamaTypes"]
+
+    HTTPXLibrary["HTTPXLibrary"]
+
+    JSONModule["JSONModule"]
+
+    OSModule["OSModule"]
+
+    PlatformModule["PlatformModule"]
+
+    Client -- "inherits from" --> BaseClient
+
+    AsyncClient -- "inherits from" --> BaseClient
+
+    Client -- "uses" --> OllamaTypes
+
+    AsyncClient -- "uses" --> OllamaTypes
+
+    Client -- "uses" --> HTTPXLibrary
+
+    AsyncClient -- "uses" --> HTTPXLibrary
+
+    Client -- "uses" --> JSONModule
+
+    AsyncClient -- "uses" --> JSONModule
+
+    BaseClient -- "uses" --> OSModule
+
+    BaseClient -- "uses" --> PlatformModule
+
+    click Client href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//Client.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `HTTP Communication Layer` is a critical subsystem within the `ollama` project, primarily responsible for all network interactions with the Ollama API. It ensures reliable, structured, and efficient communication by handling low-level HTTP requests, data serialization/deserialization, and robust error management.
+
+
+
+### BaseClient
+
+Serves as the foundational abstract class for both synchronous and asynchronous Ollama clients. It encapsulates the core logic for initializing the underlying `httpx` client, including setting the base URL, default headers (e.g., `User-Agent`, `Content-Type`, `Accept`), and processing environment variables like `OLLAMA_HOST`.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Client
+
+Extends `BaseClient` to provide the concrete implementation for making *synchronous* API requests to the Ollama service. It contains the `_request_raw` method for low-level HTTP execution and the `_request` method for higher-level request orchestration, which includes Python object serialization to JSON, JSON response deserialization to Python objects, and comprehensive error handling (e.g., `ResponseError`).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L117-L125" target="_blank" rel="noopener noreferrer">`ollama._client.Client:_request_raw` (117:125)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L128-L134" target="_blank" rel="noopener noreferrer">`ollama._client.Client:_request` (128:134)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L0-L0" target="_blank" rel="noopener noreferrer">`ollama._client.ResponseError` (0:0)</a>
+
+
+
+
+
+### AsyncClient
+
+Also extends `BaseClient`, providing the concrete implementation for making *asynchronous* API requests to the Ollama service. Similar to `Client`, it includes `_request_raw` and `_request` methods, but adapted for asynchronous HTTP execution and request orchestration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L629-L637" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient:_request_raw` (629:637)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L640-L646" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient:_request` (640:646)</a>
+
+
+
+
+
+### OllamaTypes
+
+This module defines the essential data structures (e.g., `ChatRequest`, `GenerateResponse`, `Options`) that represent the request payloads sent to and response payloads received from the Ollama API. It ensures type safety and clarity for data exchange.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L340-L357" target="_blank" rel="noopener noreferrer">`ollama._types.ChatRequest` (340:357)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L245-L257" target="_blank" rel="noopener noreferrer">`ollama._types.GenerateResponse` (245:257)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L103-L136" target="_blank" rel="noopener noreferrer">`ollama._types.Options` (103:136)</a>
+
+
+
+
+
+### HTTPXLibrary
+
+External library used for performing HTTP network requests.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### JSONModule
+
+Python's built-in module for JSON serialization and deserialization.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### OSModule
+
+Python's built-in module for interacting with the operating system, e.g., environment variables.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### PlatformModule
+
+Python's built-in module for accessing underlying platform's identifying data.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Ollama_API_Endpoints.md
+++ b/.codeboarding/Ollama_API_Endpoints.md
@@ -1,0 +1,91 @@
+```mermaid
+
+graph LR
+
+    Ollama_API_Endpoints["Ollama API Endpoints"]
+
+    click Ollama_API_Endpoints href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//Ollama_API_Endpoints.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Ollama API Endpoints
+
+This component groups all the specific functionalities exposed by the Ollama API. Each method (e.g., `generate`, `chat`, `embed`, `pull`, `push`, `create_blob`) prepares the specific request data, often utilizing `Data Transformation Utilities`, and then delegates the actual HTTP communication to the `HTTP Communication Layer`. It represents the business logic for each distinct API operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L182-L198" target="_blank" rel="noopener noreferrer">`ollama._client.Client.generate` (182:198)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L694-L710" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.generate` (694:710)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L269-L280" target="_blank" rel="noopener noreferrer">`ollama._client.Client.chat` (269:280)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L780-L791" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.chat` (780:791)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L358-L377" target="_blank" rel="noopener noreferrer">`ollama._client.Client.embed` (358:377)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L870-L889" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.embed` (870:889)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L402-L408" target="_blank" rel="noopener noreferrer">`ollama._client.Client.pull` (402:408)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L914-L920" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.pull` (914:920)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L444-L450" target="_blank" rel="noopener noreferrer">`ollama._client.Client.push` (444:450)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L956-L962" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.push` (956:962)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L559-L573" target="_blank" rel="noopener noreferrer">`ollama._client.Client.create_blob` (559:573)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1072-L1093" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.create_blob` (1072:1093)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L575-L580" target="_blank" rel="noopener noreferrer">`ollama._client.Client.list` (575:580)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1095-L1100" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.list` (1095:1100)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L582-L592" target="_blank" rel="noopener noreferrer">`ollama._client.Client.delete` (582:592)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1102-L1112" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.delete` (1102:1112)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L594-L605" target="_blank" rel="noopener noreferrer">`ollama._client.Client.copy` (594:605)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1114-L1125" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.copy` (1114:1125)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L607-L615" target="_blank" rel="noopener noreferrer">`ollama._client.Client.show` (607:615)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1127-L1135" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.show` (1127:1135)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L617-L622" target="_blank" rel="noopener noreferrer">`ollama._client.Client.ps` (617:622)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1137-L1142" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.ps` (1137:1142)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L379-L399" target="_blank" rel="noopener noreferrer">`ollama._client.Client.embeddings` (379:399)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L891-L911" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.embeddings` (891:911)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Request_Response_Data_Models.md
+++ b/.codeboarding/Request_Response_Data_Models.md
@@ -1,0 +1,225 @@
+```mermaid
+
+graph LR
+
+    SubscriptableBaseModel["SubscriptableBaseModel"]
+
+    Options["Options"]
+
+    BaseRequest["BaseRequest"]
+
+    BaseStreamableRequest["BaseStreamableRequest"]
+
+    BaseGenerateRequest["BaseGenerateRequest"]
+
+    GenerateRequest["GenerateRequest"]
+
+    Image["Image"]
+
+    Message["Message"]
+
+    Tool["Tool"]
+
+    Options -- "extends" --> SubscriptableBaseModel
+
+    BaseRequest -- "extends" --> SubscriptableBaseModel
+
+    BaseGenerateRequest -- "uses" --> Options
+
+    BaseStreamableRequest -- "extends" --> BaseRequest
+
+    BaseGenerateRequest -- "extends" --> BaseStreamableRequest
+
+    GenerateRequest -- "extends" --> BaseGenerateRequest
+
+    GenerateRequest -- "is used by" --> ollama__client
+
+    Image -- "uses" --> Message
+
+    Message -- "extends" --> SubscriptableBaseModel
+
+    Message -- "uses" --> Tool
+
+    Tool -- "extends" --> SubscriptableBaseModel
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component, primarily defined within `ollama/_types.py`, is the foundational layer for all data exchange with the Ollama API. It leverages Pydantic to define robust, type-safe data structures for requests, responses, and various nested data types. This ensures data integrity, facilitates serialization to and deserialization from JSON, and provides clear contracts for API interactions.
+
+
+
+### SubscriptableBaseModel
+
+The fundamental base class for most data models in this component. It extends Pydantic's BaseModel by adding dictionary-like access (`__getitem__`, `__setitem__`, `__contains__`, `get`) to model fields, enhancing usability and flexibility.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L18-L100" target="_blank" rel="noopener noreferrer">`ollama._types.SubscriptableBaseModel` (18:100)</a>
+
+
+
+
+
+### Options
+
+A Pydantic model defining a comprehensive set of configurable parameters for controlling the behavior of the Ollama model during both load time (e.g., `num_ctx`, `num_gpu`) and runtime (e.g., `temperature`, `top_p`, `stop`).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L103-L136" target="_blank" rel="noopener noreferrer">`ollama._types.Options` (103:136)</a>
+
+
+
+
+
+### BaseRequest
+
+An abstract base class for all API request models. It defines common fields applicable to most Ollama API requests, such as the `model` identifier.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L139-L141" target="_blank" rel="noopener noreferrer">`ollama._types.BaseRequest` (139:141)</a>
+
+
+
+
+
+### BaseStreamableRequest
+
+An abstract base class that extends `BaseRequest` by introducing the `stream` field, which controls whether the API response should be streamed or returned as a single block.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L144-L146" target="_blank" rel="noopener noreferrer">`ollama._types.BaseStreamableRequest` (144:146)</a>
+
+
+
+
+
+### BaseGenerateRequest
+
+An abstract base class for requests related to text generation. It extends `BaseStreamableRequest` and includes fields for `options` (referencing the `Options` model), `format` (for response formatting), and `keep_alive` (for model persistence).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L149-L157" target="_blank" rel="noopener noreferrer">`ollama._types.BaseGenerateRequest` (149:157)</a>
+
+
+
+
+
+### GenerateRequest
+
+A concrete Pydantic model for initiating text generation requests. It inherits from `BaseGenerateRequest` and adds specific fields like `prompt`, `suffix`, `system`, and `template` to define the input for the generation task.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L188-L210" target="_blank" rel="noopener noreferrer">`ollama._types.GenerateRequest` (188:210)</a>
+
+
+
+
+
+### Image
+
+A Pydantic model designed to handle image data within requests. It supports various input types (string, bytes, Path) and includes a custom serializer to ensure images are correctly encoded into base64 strings for API transmission.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L160-L185" target="_blank" rel="noopener noreferrer">`ollama._types.Image` (160:185)</a>
+
+
+
+
+
+### Message
+
+(Inferred from context and docstrings) A core Pydantic model representing a single message in a chat conversation. It typically includes fields like `role` (e.g., 'user', 'assistant', 'system') and `content`, and can optionally include `images` or `tool_calls`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L260-L308" target="_blank" rel="noopener noreferrer">`ollama._types.Message` (260:308)</a>
+
+
+
+
+
+### Tool
+
+(Inferred from context and docstrings) A Pydantic model defining the structure of a tool that the model can call. It typically includes a `type` field and details about the tool's `function` (e.g., name, description, parameters).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L311-L337" target="_blank" rel="noopener noreferrer">`ollama._types.Tool` (311:337)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,219 @@
+```mermaid
+
+graph LR
+
+    API_Client_Core["API Client Core"]
+
+    HTTP_Communication_Layer["HTTP Communication Layer"]
+
+    Ollama_API_Endpoints["Ollama API Endpoints"]
+
+    Request_Response_Data_Models["Request/Response Data Models"]
+
+    Data_Transformation_Utilities["Data Transformation Utilities"]
+
+    API_Client_Core -- "Initializes and exposes" --> Ollama_API_Endpoints
+
+    HTTP_Communication_Layer -- "Processes requests for" --> Ollama_API_Endpoints
+
+    HTTP_Communication_Layer -- "Uses for data handling" --> Request_Response_Data_Models
+
+    API_Client_Core -- "calls" --> Ollama_API_Endpoints
+
+    Ollama_API_Endpoints -- "Calls" --> HTTP_Communication_Layer
+
+    Ollama_API_Endpoints -- "Uses" --> Request_Response_Data_Models
+
+    Ollama_API_Endpoints -- "Uses" --> Data_Transformation_Utilities
+
+    Request_Response_Data_Models -- "Defines structures for" --> Ollama_API_Endpoints
+
+    Request_Response_Data_Models -- "Used by" --> HTTP_Communication_Layer
+
+    Request_Response_Data_Models -- "Used by" --> Data_Transformation_Utilities
+
+    Data_Transformation_Utilities -- "Called by" --> Ollama_API_Endpoints
+
+    Data_Transformation_Utilities -- "Uses" --> Request_Response_Data_Models
+
+    click API_Client_Core href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//API_Client_Core.md" "Details"
+
+    click HTTP_Communication_Layer href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//HTTP_Communication_Layer.md" "Details"
+
+    click Ollama_API_Endpoints href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//Ollama_API_Endpoints.md" "Details"
+
+    click Request_Response_Data_Models href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//Request_Response_Data_Models.md" "Details"
+
+    click Data_Transformation_Utilities href "https://github.com/ollama/ollama-python/blob/main/.codeboarding//Data_Transformation_Utilities.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `ollama-python` library's architecture is designed around a clear separation of concerns, facilitating both synchronous and asynchronous interactions with the Ollama API. The core design principles revolve around a central client, a dedicated HTTP communication layer, well-defined API endpoints, robust data modeling, and utility functions for data preparation.
+
+
+
+### API Client Core
+
+This component serves as the primary entry point for users, providing both synchronous (`Client`) and asynchronous (`AsyncClient`) interfaces to interact with the Ollama API. It encapsulates the foundational setup, including host URL parsing, HTTP client initialization (`httpx`), and default configurations (headers, timeouts). It acts as the orchestrator, exposing high-level methods that delegate to specific API functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L73-L107" target="_blank" rel="noopener noreferrer">`ollama._client.BaseClient` (73:107)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L113-L622" target="_blank" rel="noopener noreferrer">`ollama._client.Client` (113:622)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L625-L1142" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient` (625:1142)</a>
+
+
+
+
+
+### HTTP Communication Layer
+
+Responsible for all network interactions with the Ollama API. This component handles the low-level execution of raw HTTP requests (`_request_raw`) and the higher-level orchestration (`_request`), which includes request data serialization (Python objects to JSON), response deserialization (JSON to Python objects), and comprehensive error handling (e.g., `ResponseError`). It ensures reliable and structured communication with the Ollama server.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L117-L125" target="_blank" rel="noopener noreferrer">`ollama._client.Client._request_raw` (117:125)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L629-L637" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient._request_raw` (629:637)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L128-L134" target="_blank" rel="noopener noreferrer">`ollama._client.Client._request` (128:134)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L640-L646" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient._request` (640:646)</a>
+
+
+
+
+
+### Ollama API Endpoints
+
+This component groups all the specific functionalities exposed by the Ollama API. Each method (e.g., `generate`, `chat`, `embed`, `pull`, `push`, `create_blob`) prepares the specific request data, often utilizing `Data Transformation Utilities`, and then delegates the actual HTTP communication to the `HTTP Communication Layer`. It represents the business logic for each distinct API operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L182-L198" target="_blank" rel="noopener noreferrer">`ollama._client.Client.generate` (182:198)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L694-L710" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.generate` (694:710)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L269-L280" target="_blank" rel="noopener noreferrer">`ollama._client.Client.chat` (269:280)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L780-L791" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.chat` (780:791)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L358-L377" target="_blank" rel="noopener noreferrer">`ollama._client.Client.embed` (358:377)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L870-L889" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.embed` (870:889)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L402-L408" target="_blank" rel="noopener noreferrer">`ollama._client.Client.pull` (402:408)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L914-L920" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.pull` (914:920)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L444-L450" target="_blank" rel="noopener noreferrer">`ollama._client.Client.push` (444:450)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L956-L962" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.push` (956:962)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L559-L573" target="_blank" rel="noopener noreferrer">`ollama._client.Client.create_blob` (559:573)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1072-L1093" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.create_blob` (1072:1093)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L575-L580" target="_blank" rel="noopener noreferrer">`ollama._client.Client.list` (575:580)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1095-L1100" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.list` (1095:1100)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L582-L592" target="_blank" rel="noopener noreferrer">`ollama._client.Client.delete` (582:592)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1102-L1112" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.delete` (1102:1112)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L594-L605" target="_blank" rel="noopener noreferrer">`ollama._client.Client.copy` (594:605)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1114-L1125" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.copy` (1114:1125)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L607-L615" target="_blank" rel="noopener noreferrer">`ollama._client.Client.show` (607:615)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1127-L1135" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.show` (1127:1135)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L617-L622" target="_blank" rel="noopener noreferrer">`ollama._client.Client.ps` (617:622)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1137-L1142" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.ps` (1137:1142)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L379-L399" target="_blank" rel="noopener noreferrer">`ollama._client.Client.embeddings` (379:399)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L891-L911" target="_blank" rel="noopener noreferrer">`ollama._client.AsyncClient.embeddings` (891:911)</a>
+
+
+
+
+
+### Request/Response Data Models
+
+This component comprises all the Pydantic models that define the structured data for requests sent to and responses received from the Ollama API. This includes models for various API operations (e.g., `GenerateRequest`, `ChatRequest`), their corresponding responses, and common types like `Options`, `Message`, `Tool`, and error structures. These models are crucial for data validation, serialization, and deserialization, ensuring type safety and consistency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_types.py#L0-L0" target="_blank" rel="noopener noreferrer">`ollama._types` (0:0)</a>
+
+
+
+
+
+### Data Transformation Utilities
+
+This component consists of helper functions responsible for transforming or preparing complex data types (like images, message lists, or Python functions intended as tools) into the specific format required by the Ollama API. These utilities ensure that data is correctly structured and encoded before being sent as part of an API request, abstracting away the complexities of data formatting.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1145-L1147" target="_blank" rel="noopener noreferrer">`ollama._client._copy_images` (1145:1147)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1150-L1154" target="_blank" rel="noopener noreferrer">`ollama._client._copy_messages` (1150:1154)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_client.py#L1157-L1159" target="_blank" rel="noopener noreferrer">`ollama._client._copy_tools` (1157:1159)</a>
+
+- <a href="https://github.com/ollama/ollama-python/blob/master/ollama/_utils.py#L55-L88" target="_blank" rel="noopener noreferrer">`ollama._utils.convert_function_to_tool` (55:88)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR I have added diagram representation of the ollama-python codebase. You can see how it renders here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/ollama-python/on_boarding.md

The diagrams are designed so they give a high-level understanding of what the main parts of the project are and how they interact with each other. The idea is that a new contributor can find the component of interest to them and they can start working on it with appropriate context on how it fits in the bigger picture! (Also I'd be more than happy to integrate our free ghub action in the repo if you like the diagrams <3)

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Any feedback is more than welcome!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful.