### PR TITLE
types: allow additional properties in tool function schemas

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -320,14 +320,14 @@ class Tool(SubscriptableBaseModel):
     description: Optional[str] = None
 
     class Parameters(SubscriptableBaseModel):
-      model_config = ConfigDict(populate_by_name=True)
+      model_config = ConfigDict(populate_by_name=True, extra='allow')
       type: Optional[Literal['object']] = 'object'
       defs: Optional[Any] = Field(None, alias='$defs')
       items: Optional[Any] = None
       required: Optional[Sequence[str]] = None
 
       class Property(SubscriptableBaseModel):
-        model_config = ConfigDict(arbitrary_types_allowed=True)
+        model_config = ConfigDict(arbitrary_types_allowed=True, extra='allow')
 
         type: Optional[Union[str, Sequence[str]]] = None
         items: Optional[Any] = None


### PR DESCRIPTION
### Summary
This change is part of [ollama/ollama#11444](https://github.com/ollama/ollama/issues/11444) and related to [ollama/ollama#11448](https://github.com/ollama/ollama/pull/11448) where the server simplified `ToolFunction.Parameters` from a structured schema to `json.RawMessage` for better flexibility and performance.

**Problem**: The previous structured approach was limiting JSON schema flexibility and preventing support for advanced tooling scenarios that require complete schema definitions.

### What changed
- Added `extra='allow'` to `Tool.Function.Parameters` and `Property` model configurations
- Enables Pydantic models to accept additional fields beyond explicitly defined ones

### Why
- Supports complex JSON schemas with custom properties when sending tool definitions to Ollama API
- Resolves validation errors for schemas containing additional fields like validation rules, examples, or vendor extensions
- Improves compatibility with rich tool schema definitions

### Related
- https://github.com/ollama/ollama/issues/11444
- https://github.com/ollama/ollama/pull/11448