### PR TITLE
Remove the unused func `_as_path`

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1160,16 +1160,6 @@ def _copy_tools(tools: Optional[Sequence[Union[Mapping[str, Any], Tool, Callable
     yield convert_function_to_tool(unprocessed_tool) if callable(unprocessed_tool) else Tool.model_validate(unprocessed_tool)
 
 
-def _as_path(s: Optional[Union[str, PathLike]]) -> Union[Path, None]:
-  if isinstance(s, (str, Path)):
-    try:
-      if (p := Path(s)).exists():
-        return p
-    except Exception:
-      ...
-  return None
-
-
 def _parse_host(host: Optional[str]) -> str:
   """
   >>> _parse_host(None)


### PR DESCRIPTION
As the title says, removed the unused function `_as_path`.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>
