### PR TITLE
Add CLI example for streaming Ollama responses live_ollama_cli.py

### DIFF
--- a/examples/live_ollama_cli.py
+++ b/examples/live_ollama_cli.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import sys
+import requests
+import json
+
+
+def call_ollama(prompt, model="tinyllama", base_url="http://localhost:11434", stream=True):
+    """
+    Sends a prompt to the Ollama API and streams the response back.
+    """
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": stream
+    }
+
+    try:
+        response = requests.post(f"{base_url}/api/generate", json=payload, stream=stream)
+        response.raise_for_status()
+
+        if stream:
+            for line in response.iter_lines():
+                if line:
+                    data = json.loads(line.decode('utf-8'))
+                    yield data.get("response", "")
+        else:
+            yield response.json().get("response", "No response received")
+
+    except requests.RequestException as e:
+        yield f"\n[Error] Could not connect to Ollama. Is it running?\nDetails: {str(e)}\n"
+
+
+def main():
+    """
+    Main entry point for CLI usage.
+    """
+    # Get prompt from command-line or input
+    if len(sys.argv) > 1:
+        prompt = ' '.join(sys.argv[1:])
+    else:
+        prompt = input("Enter your prompt: ")
+
+    print("Thinking...\nOllama: ", end="", flush=True)
+
+    # Call Ollama and print the output in real-time
+    for chunk in call_ollama(prompt):
+        print(chunk, end="", flush=True)
+
+    print()  # Final newline
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
🚀 Add a Live Streaming CLI for Real-Time Interaction with Ollama

This PR introduces a vibrant and interactive CLI tool located at `examples/live_ollama_cli.py`, designed to showcase how users can connect with Ollama's local REST API in a **lively, character-by-character streaming experience** — just like chatting with a real AI assistant.

🎯 Highlights:
- ✨ Accepts prompts via command-line arguments or interactive input
- 💬 Streams Ollama model responses **letter-by-letter** in real time
- ⚡️ Feels like a live chat, not just a dump of text
- 🧱 Built with clean Python and `requests` (no heavy dependencies)
- 🧪 Simple UX with a “Thinking...” status and clean terminal output

📍 Use Case:
Perfect for developers who want a **fast, minimal**, and **engaging** way to test Ollama locally without writing a full app or using Python notebooks.

🧪 Tested with:
- Model: `tinyllama`
- API: `http://localhost:11434`

Thanks for checking this out! Hope this example helps more users start building cool interfaces with Ollama. 🙌
