### PR TITLE
fix: add missing 'name' field to ollama._types.ListResponse.Model

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -462,6 +462,7 @@ class ModelDetails(SubscriptableBaseModel):
 
 class ListResponse(SubscriptableBaseModel):
   class Model(SubscriptableBaseModel):
+    name: Optional[str] = None
     model: Optional[str] = None
     modified_at: Optional[datetime] = None
     digest: Optional[str] = None


### PR DESCRIPTION
## Pull Request: add missing 'name' field to ollama._types.ListResponse.Model

### What this does  
The REST endpoint `/api/tags` already returns a field called `"name"` for every model:

```json
{
  "models": [
    {
      "name": "Qwen3-Embedding:0.6B",
      "model": "Qwen3-Embedding:0.6B",
      "modified_at": "...",
      ...
    }
  ]
}
```

But the Python client class `ListResponse.Model` only maps these keys:

```python
class ListResponse(SubscriptableBaseModel):
  class Model(SubscriptableBaseModel):
    model: Optional[str] = None
    modified_at: Optional[datetime] = None
    digest: Optional[str] = None
    size: Optional[ByteSize] = None
    details: Optional[ModelDetails] = None
```

Because the extra `name` key is not listed, Pydantic discards it when the JSON is deserialized.  
This PR simply adds:

```python
  class Model(SubscriptableBaseModel):
    name: Optional[str] = None
    ...
```

to `ListResponse.Model` so the SDK keeps the same data that the server already sends.

### Why it matters  
Some downstream libraries (for example mem0) do:

```python
local_models = self.client.list()["models"]
if not any(model.get("name") == self.config.model for model in local_models):
    self.client.pull(self.config.model)
```

Today `model.get("name")` always returns `None`, causing unnecessary pulls or runtime errors.  
With this tiny change those projects work out of the box.

### Backwards compatibility  
- The new field is optional and defaults to `None`.  
- Existing code that only uses the old fields will keep working exactly as before.

### Files changed  
- `ollama/_types.py` – add one line inside `ListResponse.Model`.

### Verification
```python
from ollama import Client
client = Client()
print(client.list().models[0].dict())
# before: {'model': 'my-model', ...}   # name missing
# after : {'name': 'my-model', 'model': 'my-model', ...}
```

That’s all.