### PR TITLE
Fix link for thinking-levels.py in documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -77,4 +77,4 @@ Requirement: `pip install tqdm`
 - [thinking-generate.py](thinking-generate.py)
 
 ### Thinking (levels) - Choose the thinking level
-- [thinking-levels.py](thinking-generate.py)
+- [thinking-levels.py](thinking-levels.py)


### PR DESCRIPTION
Hi! I saw this link was broken; it seems pretty popular since folks are trying out gpt-oss. This resolves #554