### PR TITLE
examples: resolve invalid tool usage status code 400 if llm makes a mistake gpt-oss

### DIFF
--- a/examples/gpt-oss-tools-stream.py
+++ b/examples/gpt-oss-tools-stream.py
@@ -98,6 +98,7 @@ while True:
         messages.append(result_message)
       else:
         print(f'Tool {tool_call.function.name} not found')
+        messages.append({'role': 'tool', 'content': f'Tool {tool_call.function.name} not found', 'tool_name': tool_call.function.name})
 
   else:
     # no more tool calls, we can stop the loop

--- a/examples/gpt-oss-tools.py
+++ b/examples/gpt-oss-tools.py
@@ -78,7 +78,7 @@ while True:
         messages.append({'role': 'tool', 'content': result, 'tool_name': tool_call.function.name})
       else:
         print(f'Tool {tool_call.function.name} not found')
-
+        messages.append({'role': 'tool', 'content': f'Tool {tool_call.function.name} not found', 'tool_name': tool_call.function.name})
   else:
     # no more tool calls, we can stop the loop
     break


### PR DESCRIPTION
The bug this fixes.
Sometimes the LLM can make a mistake in the tool's name. The client would output `Tool x not found` and submit a new chat request. The problem is that the chat request will contain the assistant tool request, but will be missing a tool response. This results in an HTTP status code 400, `invalid tool usage`.

The patch adds a tool response when the tool is not found. This will enable the client to inform the LLM that it performed a bad tool call as a tool response and avoid the HTTP 400 error.

Test with a prompt that will invoke many tool calls like `I need the weather conditions for each state capital in the United States.`

