### PR TITLE
docs(readme): add Cloud Models Python usage and Cloud API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ for chunk in stream:
 
 Run larger models by offloading to Ollama’s cloud while keeping your local workflow.
 
-- Supported models: `deepseek-v3.1:671b-cloud`, `gpt-oss:20b-cloud`, `gpt-oss:120b-cloud`, `kimi-k2:1t-cloud`, `qwen3-coder:480b-cloud`
+- Supported models: `deepseek-v3.1:671b-cloud`, `gpt-oss:20b-cloud`, `gpt-oss:120b-cloud`, `kimi-k2:1t-cloud`, `qwen3-coder:480b-cloud`, `kimi-k2-thinking` See [Ollama Models - Cloud](https://ollama.com/search?c=cloud) for more information
 
 ### Run via local Ollama
 
@@ -70,7 +70,7 @@ ollama signin
 ollama pull gpt-oss:120b-cloud
 ```
 
-3) Use as usual (offloads automatically):
+3) Make a request:
 
 ```python
 from ollama import Client
@@ -85,14 +85,14 @@ messages = [
 ]
 
 for part in client.chat('gpt-oss:120b-cloud', messages=messages, stream=True):
-  print(part['message']['content'], end='', flush=True)
+  print(part.message.content, end='', flush=True)
 ```
 
 ### Cloud API (ollama.com)
 
 Access cloud models directly by pointing the client at `https://ollama.com`.
 
-1) Create an API key, then set:
+1) Create an API key from [ollama.com](https://ollama.com/settings/keys) , then set:
 
 ```
 export OLLAMA_API_KEY=your_api_key
@@ -123,7 +123,7 @@ messages = [
 ]
 
 for part in client.chat('gpt-oss:120b', messages=messages, stream=True):
-  print(part['message']['content'], end='', flush=True)
+  print(part.message.content, end='', flush=True)
 ```
 
 ## Custom client


### PR DESCRIPTION
Introduce a minimal, focused Cloud Models section for Python users.

Why
- Clarify how to run larger models via cloud offload while keeping local tooling.
- Document direct access to ollama.com’s API with a Python example.

What
- Add sign-in/pull/run flow for cloud models via local Ollama (automatic offload).
- Add example for direct cloud API with host="https://ollama.com" and OLLAMA_API_KEY header.
- List currently supported cloud model IDs.
- Keep examples concise; align with existing style and streaming pattern.

Scope
- Python-only; no JS/cURL duplication beyond a minimal tags listing.
- Docs-only change; no runtime or API modifications.

Validation
- Verified examples locally (streaming + basic chat).
- Ensured README ordering remains consistent.
