### PR TITLE
feat: add close() method and context manager support to Client and AsyncClient

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -124,6 +124,19 @@ class Client(BaseClient):
   def __init__(self, host: Optional[str] = None, **kwargs) -> None:
     super().__init__(httpx.Client, host, **kwargs)
 
+  def close(self) -> None:
+    """Close the underlying HTTP client and release resources."""
+    self._client.close()
+
+  def __enter__(self):
+    """Support usage as a context manager."""
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    """Ensure the client is closed when exiting the context."""
+    self.close()
+    return False
+
   def _request_raw(self, *args, **kwargs):
     try:
       r = self._client.request(*args, **kwargs)
@@ -685,6 +698,19 @@ class Client(BaseClient):
 class AsyncClient(BaseClient):
   def __init__(self, host: Optional[str] = None, **kwargs) -> None:
     super().__init__(httpx.AsyncClient, host, **kwargs)
+
+  async def close(self) -> None:
+    """Close the underlying HTTP client and release resources."""
+    await self._client.aclose()
+
+  async def __aenter__(self):
+    """Support usage as an async context manager."""
+    return self
+
+  async def __aexit__(self, exc_type, exc_val, exc_tb):
+    """Ensure the client is closed when exiting the async context."""
+    await self.close()
+    return False
 
   async def _request_raw(self, *args, **kwargs):
     try:


### PR DESCRIPTION
## Summary

Adds explicit resource management to `Client` and `AsyncClient` by implementing:
- `close()` method for manual cleanup
- Context manager protocol (`__enter__`/`__exit__`)
- Async context manager protocol (`__aenter__`/`__aexit__`)

## Motivation

Closes #532

This allows users to properly clean up HTTP connections and release resources, following Python best practices.

## Changes

### Client (synchronous)
- Added `close()` method to explicitly close the underlying `httpx.Client`
- Implemented `__enter__` and `__exit__` to support context manager usage

### AsyncClient (asynchronous)
- Added `async close()` method to explicitly close the underlying `httpx.AsyncClient`
- Implemented `__aenter__` and `__aexit__` to support async context manager usage

## Usage Examples

### Synchronous
```python
# Manual close
client = Client()
try:
    response = client.chat(model='gemma3', messages=[...])
finally:
    client.close()

# Context manager (recommended)
with Client() as client:
    response = client.chat(model='gemma3', messages=[...])
# Automatically closed
Asynchronous
# Manual close
client = AsyncClient()
try:
    response = await client.chat(model='gemma3', messages=[...])
finally:
    await client.close()

# Async context manager (recommended)
async with AsyncClient() as client:
    response = await client.chat(model='gemma3', messages=[...])
# Automatically closed
Testing
Tested manually with both synchronous and asynchronous usage patterns. All existing functionality remains unchanged.
Checklist
 Implementation follows existing code style
 Works for both Client and AsyncClient
 Maintains backward compatibility (existing code continues to work)
 Follows Python context manager protocol correctly
