### PR TITLE
fix: suppress verbose httpx request logging at INFO level

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1,6 +1,7 @@
 import contextlib
 import ipaddress
 import json
+import logging
 import os
 import platform
 import sys
@@ -25,6 +26,11 @@ from typing import (
 
 import anyio
 from pydantic.json_schema import JsonSchemaValue
+
+# Set httpx logger to WARNING level to suppress verbose HTTP request logs at INFO level.
+# Users who want to see these logs can set the level back to INFO or DEBUG in their application.
+# See: https://github.com/ollama/ollama-python/issues/539
+logging.getLogger('httpx').setLevel(logging.WARNING)
 
 from ollama._utils import convert_function_to_tool
 


### PR DESCRIPTION
## Summary
- Fixes issue #539 where httpx logs verbose HTTP request/response information at INFO level
- Sets the httpx logger to WARNING level by default, suppressing messages like:
  ```
  HTTP Request: POST http://192.168.1.118:11434/api/generate "HTTP/1.1 200 OK"
  ```

## Problem
The httpx library logs HTTP request/response information at INFO level by default. When using ollama-python in applications with standard INFO-level logging, these verbose messages clutter the logs and obscure more important application messages.

## Solution
Added a module-level configuration that sets the `httpx` logger level to WARNING:

```python
logging.getLogger('httpx').setLevel(logging.WARNING)
```

This suppresses the verbose HTTP request logs while still allowing WARNING and ERROR level messages through.

## Preserving User Control
Users who want to see HTTP request logs for debugging can still enable them by setting the httpx logger level back to INFO or DEBUG in their application:

```python
import logging
logging.getLogger('httpx').setLevel(logging.INFO)
```

## Test plan
- [x] Verified syntax is correct
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)