### PR TITLE
fix: make model_info optional in ShowResponse for cloud models

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -572,7 +572,7 @@ class ShowResponse(SubscriptableBaseModel):
 
   details: Optional[ModelDetails] = None
 
-  modelinfo: Optional[Mapping[str, Any]] = Field(alias='model_info')
+  modelinfo: Optional[Mapping[str, Any]] = Field(None, alias='model_info')
 
   parameters: Optional[str] = None
 


### PR DESCRIPTION
## Summary
Make `model_info` field optional in `ShowResponse` to handle cloud models that don't return this field from `/api/show`.

Fixes #607

## Changes
- Add `None` default value to the `model_info` field's `Field()` declaration in `ShowResponse`
- Without this default, Pydantic treats the field as required despite the `Optional` type annotation, causing a `ValidationError` when cloud models omit `model_info` from their `/api/show` response

## Test plan
- [x] Verified `ShowResponse` can be instantiated without `model_info` (cloud model scenario)
- [x] Verified `ShowResponse` still works correctly with `model_info` provided (local model scenario)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)