### PR TITLE
Fixes #623 missing __version__ attribute in module

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from ollama._client import AsyncClient, Client
 from ollama._types import (
   ChatResponse,
@@ -19,7 +20,12 @@ from ollama._types import (
   WebSearchResponse,
 )
 
+try:
+  __version__ = importlib.metadata.version('ollama')
+except importlib.metadata.PackageNotFoundError:
+  __version__ = 'unknown'
 __all__ = [
+  '__version__',
   'AsyncClient',
   'ChatResponse',
   'Client',


### PR DESCRIPTION
This pull request exposes the __version__ attribute for the ollama Python package, dynamically reading it via importlib.metadata.
Fixes #623.