### PR TITLE
Add ping method for health endpoint

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -57,3 +57,4 @@ show = _client.show
 ps = _client.ps
 web_search = _client.web_search
 web_fetch = _client.web_fetch
+ping = _client.ping

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -670,6 +670,10 @@ class Client(BaseClient):
       'GET',
       '/api/ps',
     )
+  
+  def ping(self) -> str:
+    r = self._request_raw('GET', '/')
+    return r.text
 
   def web_search(self, query: str, max_results: int = 3) -> WebSearchResponse:
     """
@@ -1305,6 +1309,10 @@ class AsyncClient(BaseClient):
       ).model_dump(exclude_none=True),
     )
 
+  async def ping(self) -> str:
+    r = await self._request_raw('GET', '/')
+    return r.text
+  
   async def ps(self) -> ProcessResponse:
     return await self._request(
       ProcessResponse,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -879,6 +879,19 @@ def test_client_copy(httpserver: HTTPServer):
   assert response['status'] == 'success'
 
 
+def test_client_ping(httpserver: HTTPServer):
+  httpserver.expect_ordered_request('/', method='GET').respond_with_response(Response('Ollama is running', status=200))
+  client = Client(httpserver.url_for('/'))
+  response = client.ping()
+  assert response == 'Ollama is running'
+
+
+def test_client_ping_connection_error():
+  client = Client('http://localhost:1')
+  with pytest.raises(ConnectionError, match=CONNECTION_ERROR_MESSAGE):
+    client.ping()
+
+
 async def test_async_client_chat(httpserver: HTTPServer):
   httpserver.expect_ordered_request(
     '/api/chat',
@@ -1254,6 +1267,19 @@ async def test_async_client_copy(httpserver: HTTPServer):
   client = AsyncClient(httpserver.url_for('/api/copy'))
   response = await client.copy('dum', 'dummer')
   assert response['status'] == 'success'
+
+
+async def test_async_client_ping(httpserver: HTTPServer):
+  httpserver.expect_ordered_request('/', method='GET').respond_with_response(Response('Ollama is running', status=200))
+  client = AsyncClient(httpserver.url_for('/'))
+  response = await client.ping()
+  assert response == 'Ollama is running'
+
+
+async def test_async_client_ping_connection_error():
+  client = AsyncClient('http://localhost:1')
+  with pytest.raises(ConnectionError, match=CONNECTION_ERROR_MESSAGE):
+    await client.ping()
 
 
 def test_headers():


### PR DESCRIPTION
Closes #121

Adds a ping() method to both Client and AsyncClient that hits the GET / health endpoint and returns the response text ("Ollama is running"). Raises ConnectionError if the server is unreachable.

client = ollama.Client()
client.ping()  # "Ollama is running"

Changes:
- ollama/_client.py — added ping() to Client and AsyncClient
- tests/test_client.py — added tests for success and connection error cases (sync and async)
