### PR TITLE
fix: add missing authorization check in AsyncClient web_search and web_fetch

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -801,7 +801,12 @@ class AsyncClient(BaseClient):
 
     Returns:
       WebSearchResponse with the search results
+    Raises:
+      ValueError: If OLLAMA_API_KEY environment variable is not set
     """
+    if not self._client.headers.get('authorization', '').startswith('Bearer '):
+      raise ValueError('Authorization header with Bearer token is required for web search')
+
     return await self._request(
       WebSearchResponse,
       'POST',
@@ -821,7 +826,12 @@ class AsyncClient(BaseClient):
 
     Returns:
       WebFetchResponse with the fetched result
+    Raises:
+      ValueError: If OLLAMA_API_KEY environment variable is not set
     """
+    if not self._client.headers.get('authorization', '').startswith('Bearer '):
+      raise ValueError('Authorization header with Bearer token is required for web fetch')
+
     return await self._request(
       WebFetchResponse,
       'POST',


### PR DESCRIPTION
## Problem

The synchronous `Client.web_search` and `Client.web_fetch` methods both validate that the authorization header contains a Bearer token before making requests to `ollama.com/api/web_search` and `ollama.com/api/web_fetch`. This gives users a clear, immediate error if they haven't configured their API key.

However, the async equivalents in `AsyncClient` skip this validation entirely. When an async user calls `web_search` or `web_fetch` without proper auth, the request goes through to the server and fails with an opaque server-side error instead of the helpful `ValueError` that sync users get.

## Fix

Added the same Bearer token authorization check to `AsyncClient.web_search` and `AsyncClient.web_fetch` that already exists in their sync counterparts:

```python
if not self._client.headers.get('authorization', '').startswith('Bearer '):
    raise ValueError('Authorization header with Bearer token is required for web search')
```

Also updated the docstrings to include the `Raises` section documenting the `ValueError`, matching the sync versions.

## Testing

- Verified that calling `AsyncClient.web_search()` without a Bearer token now raises `ValueError` with a descriptive message
- Verified that calling `AsyncClient.web_fetch()` without a Bearer token now raises `ValueError` with a descriptive message
- Verified that both methods still work correctly when a valid Bearer token is present
- Confirmed sync `Client` behavior is unchanged