### PR TITLE
fix: preserve falsy values like empty strings in _copy_messages

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1321,7 +1321,7 @@ def _copy_images(images: Optional[Sequence[Union[Image, Any]]]) -> Iterator[Imag
 def _copy_messages(messages: Optional[Sequence[Union[Mapping[str, Any], Message]]]) -> Iterator[Message]:
   for message in messages or []:
     yield Message.model_validate(
-      {k: list(_copy_images(v)) if k == 'images' else v for k, v in dict(message).items() if v},
+      {k: list(_copy_images(v)) if k == 'images' else v for k, v in dict(message).items() if v is not None},
     )
 
 


### PR DESCRIPTION
## Problem

In `_copy_messages`, the dictionary comprehension uses `if v` to filter out entries:

```python
{k: list(_copy_images(v)) if k == 'images' else v for k, v in dict(message).items() if v}
```

This filter removes all falsy values, not just None. In practice this means:

- `content: ""` (empty string) gets silently dropped
- `content: 0` (integer zero) gets silently dropped
- `content: False` (boolean) gets silently dropped

This is particularly problematic for the content field. An empty string is a valid message content value (for example, tool-call messages where the model response has no text content, just a tool call). Dropping it changes the message structure and can cause issues with downstream processing or serialization that expects the key to be present.

## Fix

Changed the filter from `if v` to `if v is not None`:

```python
{k: list(_copy_images(v)) if k == 'images' else v for k, v in dict(message).items() if v is not None}
```

This preserves empty strings, zero, False, and empty lists while still filtering out fields that are genuinely unset (None).

## Testing

- Verified that messages with `content: ""` now correctly preserve the empty string
- Verified that None values are still properly filtered out
- Verified that normal messages with non-empty content are unaffected