### PR TITLE
Add link to examples directory in README (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ print(response.message.content)
 
 See [_types.py](ollama/_types.py) for more information on the response types.
 
+## Examples
+
+See the examples in [`examples/`](examples/) for additional usage patterns, including:
+
+- chat (with and without streaming)
+- chat with history
+- tools / function calling
+- structured outputs
+- multimodal and image generation
+- embeddings and model management
+
 ## Streaming responses
 
 Response streaming can be enabled by setting `stream=True`.


### PR DESCRIPTION
Adds a link to the examples directory to improve discoverability of usage patterns.

The repository already includes a comprehensive set of examples (chat, streaming, tools, structured outputs, etc.), but they are not referenced from the main README.

This addresses #126.