### PR TITLE
fix: handle multiple tool calls in tools examples

### DIFF
--- a/examples/async-tools.py
+++ b/examples/async-tools.py
@@ -62,6 +62,9 @@ async def main():
 
   if response.message.tool_calls:
     # There may be multiple tool calls in the response
+    # Add the assistant message with tool calls to the conversation
+    messages.append(response.message)
+
     for tool in response.message.tool_calls:
       # Ensure the function is available, and then call it
       if function_to_call := available_functions.get(tool.function.name):
@@ -71,14 +74,12 @@ async def main():
         print('Function output:', output)
       else:
         print('Function', tool.function.name, 'not found')
+        output = 'Function not found'
 
-  # Only needed to chat with the model using the tool call results
-  if response.message.tool_calls:
-    # Add the function response to messages for the model to use
-    messages.append(response.message)
-    messages.append({'role': 'tool', 'content': str(output), 'tool_name': tool.function.name})
+      # Add each tool result as a separate message
+      messages.append({'role': 'tool', 'content': str(output), 'tool_name': tool.function.name})
 
-    # Get final response from model with function outputs
+    # Get final response from model with all tool call results
     final_response = await client.chat('llama3.1', messages=messages)
     print('Final response:', final_response.message.content)
 

--- a/examples/tools.py
+++ b/examples/tools.py
@@ -60,6 +60,9 @@ response: ChatResponse = chat(
 
 if response.message.tool_calls:
   # There may be multiple tool calls in the response
+  # Add the assistant message with tool calls to the conversation
+  messages.append(response.message)
+
   for tool in response.message.tool_calls:
     # Ensure the function is available, and then call it
     if function_to_call := available_functions.get(tool.function.name):
@@ -69,14 +72,12 @@ if response.message.tool_calls:
       print('Function output:', output)
     else:
       print('Function', tool.function.name, 'not found')
+      output = 'Function not found'
 
-# Only needed to chat with the model using the tool call results
-if response.message.tool_calls:
-  # Add the function response to messages for the model to use
-  messages.append(response.message)
-  messages.append({'role': 'tool', 'content': str(output), 'tool_name': tool.function.name})
+    # Add each tool result as a separate message
+    messages.append({'role': 'tool', 'content': str(output), 'tool_name': tool.function.name})
 
-  # Get final response from model with function outputs
+  # Get final response from model with all tool call results
   final_response = chat('llama3.1', messages=messages)
   print('Final response:', final_response.message.content)
 


### PR DESCRIPTION
## Summary
- Fixes the `tools.py` and `async-tools.py` examples so that **all** tool call results are sent back to the model, not just the last one
- Previously, the examples iterated over tool calls but only appended a single `tool` message **after** the loop using the last value of `output`, which meant earlier tool call results were silently discarded
- Each tool result is now appended as a separate message inside the loop, consistent with the pattern already used in `multi-tool.py` and `gpt-oss-tools.py`

Fixes #476

## Changes
- **`examples/tools.py`**: Move `messages.append(response.message)` before the loop; append each tool result inside the loop
- **`examples/async-tools.py`**: Same fix applied to the async variant

## Test plan
- [x] `ruff check` passes on both changed files
- [x] Python syntax validation passes
- [ ] Manual verification: run `tools.py` with a prompt that triggers multiple tool calls (e.g., "What is three plus one, then subtract two?") and confirm all results are sent to the model