### PR TITLE
fix: add __version__ attribute to package

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version as _get_version
+
 from ollama._client import AsyncClient, Client
 from ollama._types import (
   ChatResponse,
@@ -19,6 +21,11 @@ from ollama._types import (
   WebSearchResponse,
 )
 
+try:
+  __version__ = _get_version('ollama')
+except Exception:
+  __version__ = '0.0.0'
+
 __all__ = [
   'AsyncClient',
   'ChatResponse',
@@ -39,6 +46,7 @@ __all__ = [
   'Tool',
   'WebFetchResponse',
   'WebSearchResponse',
+  '__version__',
 ]
 
 _client = Client()


### PR DESCRIPTION
## Summary

The ollama package was missing a `__version__` attribute, causing `AttributeError: module 'ollama' has no attribute '__version__'` when users try to access `ollama.__version__`.

## Changes

- Added `__version__` attribute using `importlib.metadata.version('ollama')`
- Falls back to `'0.0.0'` if metadata is unavailable (e.g., when running from source)
- Added `'__version__'` to `__all__` for proper exports

## Testing

```python
>>> import ollama
>>> ollama.__version__
'0.6.2'
```

Fixes #623