### PR TITLE
fix: make model_info optional in ShowResponse for cloud models

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -572,7 +572,7 @@ class ShowResponse(SubscriptableBaseModel):
 
   details: Optional[ModelDetails] = None
 
-  modelinfo: Optional[Mapping[str, Any]] = Field(alias='model_info')
+  modelinfo: Optional[Mapping[str, Any]] = Field(default=None, alias='model_info')
 
   parameters: Optional[str] = None
 


### PR DESCRIPTION
Fixes #607.

## Problem

Some cloud models (e.g. glm-4.7:cloud, qwen3-next:80b-cloud, deepseek-v3.2:cloud) return /api/show responses that omit the model_info field entirely. The ShowResponse Pydantic model has model_info typed as Optional but uses Field(alias=...) without a default value, which makes Pydantic treat it as required:



## Fix

One-line change in _types.py:



Adding default=None makes Pydantic respect the Optional type hint when the field is missing from the API response.

## Testing

Verified both cases:
- Response without model_info (cloud models): parses successfully, modelinfo is None
- Response with model_info (standard models): parses successfully, modelinfo contains the data