### PR TITLE
docs: add module docstrings to example scripts

### DIFF
--- a/examples/chat-stream.py
+++ b/examples/chat-stream.py
@@ -1,3 +1,15 @@
+"""Streaming chat response.
+
+Prints tokens as they are generated instead of waiting for the full
+response, providing a real-time typing effect.
+
+Prerequisites:
+    ollama pull gemma3
+
+Usage:
+    python chat-stream.py
+"""
+
 from ollama import chat
 
 messages = [

--- a/examples/chat-with-history.py
+++ b/examples/chat-with-history.py
@@ -1,3 +1,15 @@
+"""Multi-turn chat with conversation history.
+
+Sends multiple messages in sequence, maintaining context across turns
+so the model can reference earlier parts of the conversation.
+
+Prerequisites:
+    ollama pull gemma3
+
+Usage:
+    python chat-with-history.py
+"""
+
 from ollama import chat
 
 messages = [

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -1,3 +1,14 @@
+"""Basic chat completion.
+
+Sends a single user message and prints the model's response.
+
+Prerequisites:
+    ollama pull gemma3
+
+Usage:
+    python chat.py
+"""
+
 from ollama import chat
 
 messages = [

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -1,3 +1,15 @@
+"""Generate text embeddings.
+
+Produces a vector embedding for the given input text, useful for
+semantic search, clustering, and similarity comparisons.
+
+Prerequisites:
+    ollama pull llama3.2
+
+Usage:
+    python embed.py
+"""
+
 from ollama import embed
 
 response = embed(model='llama3.2', input='Hello, world!')

--- a/examples/generate.py
+++ b/examples/generate.py
@@ -1,3 +1,14 @@
+"""Basic text generation.
+
+Generates a response from a prompt without conversation history.
+
+Prerequisites:
+    ollama pull gemma3
+
+Usage:
+    python generate.py
+"""
+
 from ollama import generate
 
 response = generate('gemma3', 'Why is the sky blue?')

--- a/examples/multimodal-chat.py
+++ b/examples/multimodal-chat.py
@@ -1,3 +1,15 @@
+"""Multimodal chat with image input.
+
+Sends an image alongside a text prompt, allowing the model to describe
+or answer questions about the image content.
+
+Prerequisites:
+    ollama pull gemma3
+
+Usage:
+    python multimodal-chat.py
+"""
+
 from ollama import chat
 
 # from pathlib import Path

--- a/examples/structured-outputs.py
+++ b/examples/structured-outputs.py
@@ -1,3 +1,16 @@
+"""Structured JSON output with Pydantic validation.
+
+Forces the model to return JSON conforming to a Pydantic schema,
+then validates the response automatically.
+
+Prerequisites:
+    pip install pydantic
+    ollama pull llama3.1:8b
+
+Usage:
+    python structured-outputs.py
+"""
+
 from pydantic import BaseModel
 
 from ollama import chat

--- a/examples/tools.py
+++ b/examples/tools.py
@@ -1,3 +1,15 @@
+"""Tool calling (function calling) with Ollama.
+
+Demonstrates how to define Python functions as tools that the model can
+invoke, dispatch the calls, and feed results back into the conversation.
+
+Prerequisites:
+    ollama pull llama3.1
+
+Usage:
+    python tools.py
+"""
+
 from ollama import ChatResponse, chat
 
 


### PR DESCRIPTION
## Summary

Adds module-level docstrings to 8 example scripts explaining what each demonstrates, prerequisites (which model to pull), and how to run it.

Currently none of the examples have docstrings, which means newcomers have to read through the code to understand what each file does.

## Files Changed

| File | Description Added |
|---|---|
| chat.py | Basic chat completion |
| generate.py | Basic text generation |
| embed.py | Text embeddings |
| tools.py | Tool/function calling |
| structured-outputs.py | Pydantic-validated JSON output |
| chat-stream.py | Streaming responses |
| chat-with-history.py | Multi-turn conversation |
| multimodal-chat.py | Image + text input |

## Format

Each docstring follows the same structure:
1. One-line summary
2. Brief explanation
3. Prerequisites (model to pull, extra deps)
4. Usage command

## Test Plan

- [x] Documentation only, no logic changes