### PR TITLE
feat: add __enter__ and __aenter__ for context manager support

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -117,8 +117,14 @@ class BaseClient(contextlib.AbstractContextManager, contextlib.AbstractAsyncCont
       **kwargs,
     )
 
+  def __enter__(self):
+    return self
+
   def __exit__(self, exc_type, exc_val, exc_tb):
     self.close()
+
+  async def __aenter__(self):
+    return self
 
   async def __aexit__(self, exc_type, exc_val, exc_tb):
     await self.close()


### PR DESCRIPTION
Adds missing __enter__ and __aenter__ to BaseClient. close()/__exit__ already existed but without entry methods, `with Client() as c:` raised TypeError.