### PR TITLE
fix: ShowResponse raises ValidationError when model_info is omitted

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -562,6 +562,8 @@ class ShowRequest(BaseRequest):
 
 
 class ShowResponse(SubscriptableBaseModel):
+  model_config = ConfigDict(populate_by_name=True)
+
   modified_at: Optional[datetime] = None
 
   template: Optional[str] = None
@@ -572,7 +574,7 @@ class ShowResponse(SubscriptableBaseModel):
 
   details: Optional[ModelDetails] = None
 
-  modelinfo: Optional[Mapping[str, Any]] = Field(alias='model_info')
+  modelinfo: Optional[Mapping[str, Any]] = Field(default=None, alias='model_info')
 
   parameters: Optional[str] = None
 

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -92,3 +92,35 @@ def test_create_request_serialization_license_list():
   request = CreateRequest(model='test-model', license=['MIT', 'Apache-2.0'])
   serialized = request.model_dump()
   assert serialized['license'] == ['MIT', 'Apache-2.0']
+
+
+def test_show_response_without_model_info():
+  """ShowResponse should accept responses that omit model_info (e.g. cloud models).
+
+  Regression test for https://github.com/ollama/ollama-python/issues/607
+  """
+  from ollama._types import ShowResponse
+
+  # model_info completely absent from response
+  resp = ShowResponse()
+  assert resp.modelinfo is None
+
+  resp = ShowResponse(template='{{ .Prompt }}')
+  assert resp.modelinfo is None
+  assert resp.template == '{{ .Prompt }}'
+
+
+def test_show_response_with_model_info_alias():
+  """ShowResponse should accept model_info via its alias."""
+  from ollama._types import ShowResponse
+
+  resp = ShowResponse(model_info={'general.architecture': 'llama'})
+  assert resp.modelinfo == {'general.architecture': 'llama'}
+
+
+def test_show_response_with_modelinfo_field_name():
+  """ShowResponse should accept modelinfo via its Python field name."""
+  from ollama._types import ShowResponse
+
+  resp = ShowResponse(modelinfo={'general.architecture': 'llama'})
+  assert resp.modelinfo == {'general.architecture': 'llama'}


### PR DESCRIPTION
## Summary

Fixes #607

`ShowResponse` raises a `Pydantic ValidationError` when the `/api/show` endpoint omits `model_info` from its response. This happens with some cloud models and breaks downstream tools like `llm-ollama`.

## Root Cause

`modelinfo` uses `Field(alias='model_info')` with `Optional[Mapping]` type, but Pydantic requires an explicit `default=None` for aliased Optional fields. Without it, the field is treated as required even though the type hint suggests otherwise.

## Changes

- **`ollama/_types.py`**: Added `model_config = ConfigDict(populate_by_name=True)` and `default=None` to the `modelinfo` field on `ShowResponse`
- **`tests/test_type_serialization.py`**: Added 3 tests covering the fix:
  - `test_show_response_without_model_info` — verifies no error when model_info is absent
  - `test_show_response_with_model_info_alias` — verifies the alias still works
  - `test_show_response_with_modelinfo_field_name` — verifies the Python field name works

## Testing

```
13 passed in 0.18s
```

All existing tests continue to pass.