### PR TITLE
feat: add client.exists() to check if a model is available locally

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -52,6 +52,7 @@ push = _client.push
 create = _client.create
 delete = _client.delete
 list = _client.list
+exists = _client.exists
 copy = _client.copy
 show = _client.show
 ps = _client.ps

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -629,6 +629,18 @@ class Client(BaseClient):
       '/api/tags',
     )
 
+  def exists(self, model: str) -> bool:
+    """Check if a model is available locally.
+
+    Args:
+      model: The model name to check (e.g. 'llama3.1:8b').
+
+    Returns:
+      True if the model exists locally, False otherwise.
+    """
+    models = self.list().models or []
+    return any(m.model == model for m in models)
+
   def delete(self, model: str) -> StatusResponse:
     r = self._request_raw(
       'DELETE',
@@ -1269,6 +1281,19 @@ class AsyncClient(BaseClient):
       'GET',
       '/api/tags',
     )
+
+  async def exists(self, model: str) -> bool:
+    """Check if a model is available locally.
+
+    Args:
+      model: The model name to check (e.g. 'llama3.1:8b').
+
+    Returns:
+      True if the model exists locally, False otherwise.
+    """
+    resp = await self.list()
+    models = resp.models or []
+    return any(m.model == model for m in models)
 
   async def delete(self, model: str) -> StatusResponse:
     r = await self._request_raw(

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -1,0 +1,82 @@
+import json
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from ollama._client import AsyncClient, Client
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+  return 'asyncio'
+
+
+def test_client_exists_true(httpserver: HTTPServer):
+  """exists() returns True when model is present."""
+  httpserver.expect_ordered_request(
+    '/api/tags',
+    method='GET',
+  ).respond_with_json({
+    'models': [
+      {'name': 'llama3.1:8b', 'model': 'llama3.1:8b', 'size': 4661224676},
+      {'name': 'qwen2.5:latest', 'model': 'qwen2.5:latest', 'size': 4430121000},
+    ]
+  })
+
+  client = Client(host=f'http://{httpserver.host}:{httpserver.port}')
+  assert client.exists('llama3.1:8b') is True
+
+
+def test_client_exists_false(httpserver: HTTPServer):
+  """exists() returns False when model is not present."""
+  httpserver.expect_ordered_request(
+    '/api/tags',
+    method='GET',
+  ).respond_with_json({
+    'models': [
+      {'name': 'llama3.1:8b', 'model': 'llama3.1:8b', 'size': 4661224676},
+    ]
+  })
+
+  client = Client(host=f'http://{httpserver.host}:{httpserver.port}')
+  assert client.exists('gemma2:2b') is False
+
+
+def test_client_exists_empty_list(httpserver: HTTPServer):
+  """exists() returns False when no models are available."""
+  httpserver.expect_ordered_request(
+    '/api/tags',
+    method='GET',
+  ).respond_with_json({'models': []})
+
+  client = Client(host=f'http://{httpserver.host}:{httpserver.port}')
+  assert client.exists('llama3.1:8b') is False
+
+
+async def test_async_client_exists_true(httpserver: HTTPServer):
+  """Async exists() returns True when model is present."""
+  httpserver.expect_ordered_request(
+    '/api/tags',
+    method='GET',
+  ).respond_with_json({
+    'models': [
+      {'name': 'llama3.1:8b', 'model': 'llama3.1:8b', 'size': 4661224676},
+    ]
+  })
+
+  client = AsyncClient(host=f'http://{httpserver.host}:{httpserver.port}')
+  assert await client.exists('llama3.1:8b') is True
+
+
+async def test_async_client_exists_false(httpserver: HTTPServer):
+  """Async exists() returns False when model is not present."""
+  httpserver.expect_ordered_request(
+    '/api/tags',
+    method='GET',
+  ).respond_with_json({'models': []})
+
+  client = AsyncClient(host=f'http://{httpserver.host}:{httpserver.port}')
+  assert await client.exists('nonexistent') is False


### PR DESCRIPTION
## Summary

Implements #640 — adds `exists()` method to `Client` and `AsyncClient` that checks if a specific model is already pulled locally.

## Changes

- Added `Client.exists(model: str) -> bool` — wraps `list()` to check for a model by name
- Added `AsyncClient.exists(model: str) -> bool` — async version
- Added top-level `ollama.exists()` convenience function
- 5 tests covering: found, not found, empty list, async variants

## Usage

```python
import ollama

# Check before pulling
if not ollama.exists("llama3.1:8b"):
    ollama.pull("llama3.1:8b")

# Or with client
client = ollama.Client()
if client.exists("qwen2.5:latest"):
    response = client.chat("qwen2.5:latest", messages=[...])
```

## Testing

```
5 tests — all passing
- test_client_exists_true
- test_client_exists_false  
- test_client_exists_empty_list
- test_async_client_exists_true
- test_async_client_exists_false
```