### PR TITLE
feat: add helpers to expose package version and server version API 

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -1,4 +1,4 @@
-from ollama._client import AsyncClient, Client
+from ollama._client import AsyncClient, Client, __version__
 from ollama._types import (
   ChatResponse,
   EmbeddingsResponse,
@@ -23,6 +23,8 @@ __all__ = [
   'AsyncClient',
   'ChatResponse',
   'Client',
+  '__version__',
+  'version',
   'EmbedResponse',
   'EmbeddingsResponse',
   'GenerateResponse',
@@ -55,5 +57,6 @@ list = _client.list
 copy = _client.copy
 show = _client.show
 ps = _client.ps
+version = _client.version
 web_search = _client.web_search
 web_fetch = _client.web_fetch

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -628,6 +628,16 @@ class Client(BaseClient):
       'GET',
       '/api/tags',
     )
+  
+  def version(self) -> str:
+    r = self._request_raw(
+      'GET',
+      '/api/version'
+    )
+    if r.status_code != 200:
+      raise Exception(f"Request failed: {r.status_code}")
+
+    return r.json().get('version', '')
 
   def delete(self, model: str) -> StatusResponse:
     r = self._request_raw(
@@ -1269,6 +1279,18 @@ class AsyncClient(BaseClient):
       'GET',
       '/api/tags',
     )
+
+  async def version(self) -> str:
+    r = await self._request_raw(
+      'GET',
+      '/api/version',
+    )
+
+    if r.status_code != 200:
+      raise Exception(f"Request failed: {r.status_code}")
+    
+    return r.json().get('version', '')
+  
 
   async def delete(self, model: str) -> StatusResponse:
     r = await self._request_raw(

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -634,9 +634,6 @@ class Client(BaseClient):
       'GET',
       '/api/version'
     )
-    if r.status_code != 200:
-      raise Exception(f"Request failed: {r.status_code}")
-
     return r.json().get('version', '')
 
   def delete(self, model: str) -> StatusResponse:
@@ -1285,10 +1282,6 @@ class AsyncClient(BaseClient):
       'GET',
       '/api/version',
     )
-
-    if r.status_code != 200:
-      raise Exception(f"Request failed: {r.status_code}")
-    
     return r.json().get('version', '')
   
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-
+import ollama
 import pytest
 from httpx import Response as httpxResponse
 from pydantic import BaseModel
@@ -98,6 +98,50 @@ def test_client_chat_with_logprobs(httpserver: HTTPServer):
   assert response['logprobs'][0]['token'] == 'Hello'
   assert response['logprobs'][0]['top_logprobs'][1]['token'] == 'Hi'
 
+
+def test_package_version():
+  assert hasattr(ollama, '__version__')
+  assert isinstance(ollama.__version__, str)
+  assert ollama.__version__ != ''
+  assert callable(ollama.version)
+  assert hasattr(ollama, 'version')
+
+
+def test_client_version_missing_field(httpserver: HTTPServer):
+  httpserver.expect_ordered_request(
+    '/api/version',
+    method='GET',
+  ).respond_with_json({})
+
+  client = Client(httpserver.url_for('/'))
+  response = client.version()
+  assert response == ''
+
+
+async def test_async_client_version(httpserver: HTTPServer):
+  httpserver.expect_ordered_request(
+    '/api/version',
+    method='GET',
+  ).respond_with_json(
+    {
+      'version': '0.1.0',
+    }
+  )
+
+  client = AsyncClient(httpserver.url_for('/'))
+  response = await client.version()
+  assert response == '0.1.0'
+  assert isinstance(response, str)
+
+async def test_async_client_version_missing_field(httpserver: HTTPServer):
+  httpserver.expect_ordered_request(
+    '/api/version',
+    method='GET',
+  ).respond_with_json({})
+
+  client = AsyncClient(httpserver.url_for('/'))
+  response = await client.version()
+  assert response == ''
 
 def test_client_chat_stream(httpserver: HTTPServer):
   def stream_handler(_: Request):


### PR DESCRIPTION
Closes #646

There was no clean way to check the installed package version or query the running Ollama server version from Python without resorting to workarounds like parsing package metadata manually or catching exceptions.

This PR exposes two things:

- `ollama.__version__`  :  already existed internally in `_client.py` for the User-Agent header, just not exported. Now re-exported via `__init__.py`.
- `ollama.version()`  :  top-level alias for `Client.version()`, which calls  `GET /api/version` and returns the version string. `AsyncClient.version()` added for completeness.

## Usage

```python
import ollama

print(ollama.__version__)   # package version e.g. "0.6.1"
print(ollama.version())     # server version e.g. "0.18.2"
```
## Changes

- `ollama/__init__.py` :  exports `__version__` and wires `version` as a top-level alias
- `ollama/_client.py`  :  adds `version()` to `Client` and `AsyncClient`
- `tests/test_client.py`  :  4 new tests: package attribute check, sync/async , missing field edge case

## Tests
All tests pass locally.
Command used:
`pytest tests/test_client.py`

Result : 
```
76 passed in 2.32s 
```