### PR TITLE
feat: add exists() convenience method to Client and AsyncClient

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -664,6 +664,32 @@ class Client(BaseClient):
       ).model_dump(exclude_none=True),
     )
 
+  def exists(self, model: str) -> bool:
+    """
+    Check whether a model is available locally.
+
+    This is a convenience wrapper around :meth:`show` that returns a
+    plain ``bool`` instead of raising :class:`ResponseError` when the
+    model is not found, making it suitable for use in ``if`` statements
+    without exception-based control flow.
+
+    Args:
+      model: The name of the model to check (e.g. ``"llama3.1:8b"``).
+
+    Returns:
+      ``True`` if the model exists locally, ``False`` otherwise.
+
+    Example::
+
+      if not ollama.exists("llama3.1:8b"):
+          ollama.pull("llama3.1:8b")
+    """
+    try:
+      self.show(model)
+      return True
+    except ResponseError:
+      return False
+
   def ps(self) -> ProcessResponse:
     return self._request(
       ProcessResponse,
@@ -1304,6 +1330,29 @@ class AsyncClient(BaseClient):
         model=model,
       ).model_dump(exclude_none=True),
     )
+
+  async def exists(self, model: str) -> bool:
+    """
+    Check whether a model is available locally.
+
+    Async variant of :meth:`Client.exists`.
+
+    Args:
+      model: The name of the model to check (e.g. ``"llama3.1:8b"``).
+
+    Returns:
+      ``True`` if the model exists locally, ``False`` otherwise.
+
+    Example::
+
+      if not await client.exists("llama3.1:8b"):
+          await client.pull("llama3.1:8b")
+    """
+    try:
+      await self.show(model)
+      return True
+    except ResponseError:
+      return False
 
   async def ps(self) -> ProcessResponse:
     return await self._request(


### PR DESCRIPTION
Closes #640

## What

Adds `exists(model: str) -> bool` to both `Client` and `AsyncClient`.

```python
# Before
try:
    ollama.show("llama3.1:8b")
except ollama.ResponseError:
    ollama.pull("llama3.1:8b")

# After
if not ollama.exists("llama3.1:8b"):
    ollama.pull("llama3.1:8b")
```

## Implementation

Thin wrapper around `show()` that catches `ResponseError` and returns `False` instead of propagating the exception. Returns `True` if `show()` succeeds.

Both the sync and async variants are added to `_client.py` following the exact same patterns as the existing `show()` methods directly above them.

## Files changed

- `ollama/_client.py` — adds `Client.exists()` and `AsyncClient.exists()`