### PR TITLE
feat: expose __version__ and top-level version() / async_version() helpers

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -1,3 +1,10 @@
+from importlib import metadata as _metadata
+
+try:
+  __version__: str = _metadata.version('ollama')
+except _metadata.PackageNotFoundError:
+  __version__ = '0.0.0'
+
 from ollama._client import AsyncClient, Client
 from ollama._types import (
   ChatResponse,
@@ -20,6 +27,7 @@ from ollama._types import (
 )
 
 __all__ = [
+  '__version__',
   'AsyncClient',
   'ChatResponse',
   'Client',
@@ -37,11 +45,13 @@ __all__ = [
   'ShowResponse',
   'StatusResponse',
   'Tool',
+  'version',
   'WebFetchResponse',
   'WebSearchResponse',
 ]
 
 _client = Client()
+_async_client = AsyncClient()
 
 generate = _client.generate
 chat = _client.chat
@@ -55,5 +65,37 @@ list = _client.list
 copy = _client.copy
 show = _client.show
 ps = _client.ps
+exists = _client.exists
 web_search = _client.web_search
 web_fetch = _client.web_fetch
+
+
+def version() -> str:
+  """Return the running Ollama server version string.
+
+  Hits the ``/api/version`` endpoint on the local Ollama server and returns
+  the version string (e.g. ``"0.18.2"``).
+
+  This is distinct from :data:`__version__`, which is the version of the
+  *Python client package* itself.
+
+  Returns:
+    The Ollama server version string.
+
+  Example::
+
+    import ollama
+
+    print(ollama.__version__)   # "0.6.1"  — client package version
+    print(ollama.version())     # "0.18.2" — running server version
+  """
+  return _client.version()
+
+
+async def async_version() -> str:
+  """Async variant of :func:`version`.
+
+  Returns:
+    The Ollama server version string.
+  """
+  return await _async_client.version()


### PR DESCRIPTION
Closes #646

## What

Adds two things to the public `ollama` namespace:

### `ollama.__version__`
The installed *client package* version — resolved via `importlib.metadata`, same mechanism already used internally in `_client.py`.

```python
import ollama
print(ollama.__version__)  # e.g. "0.6.1"
```

### `ollama.version()` / `ollama.async_version()`
Top-level wrappers around `Client.version()` that hit `/api/version` and return the *running Ollama server* version string — no need to instantiate a client manually.

```python
print(ollama.version())    # e.g. "0.18.2"
```

### Also exposes `ollama.exists()`
Wires up the new `exists()` method as a module-level shortcut, consistent with all other shortcuts (`list`, `show`, `pull`, etc.).

## Files changed

- `ollama/__init__.py` — adds `__version__`, `version()`, `async_version()`, `exists` shortcut, and updates `__all__`