### PR TITLE
feat(types): add Audio class and audio field to Message for multimodal models

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -186,6 +186,34 @@ class Image(BaseModel):
         raise ValueError('Invalid image data, expected base64 string or path to image file') from Exception
 
 
+class Audio(BaseModel):
+  value: Union[str, bytes, Path]
+
+  @model_serializer
+  def serialize_model(self):
+    if isinstance(self.value, (Path, bytes)):
+      return b64encode(self.value.read_bytes() if isinstance(self.value, Path) else self.value).decode()
+
+    if isinstance(self.value, str):
+      try:
+        if Path(self.value).exists():
+          return b64encode(Path(self.value).read_bytes()).decode()
+      except Exception:
+        # Long base64 string can't be wrapped in Path, so try to treat as base64 string
+        pass
+
+      # String might be a file path, but might not exist
+      if self.value.split('.')[-1] in ('mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'):
+        raise ValueError(f'File {self.value} does not exist')
+
+      try:
+        # Try to decode to check if it is already base64
+        b64decode(self.value)
+        return self.value
+      except Exception:
+        raise ValueError('Invalid audio data, expected base64 string or path to audio file') from Exception
+
+
 class GenerateRequest(BaseGenerateRequest):
   prompt: Optional[str] = None
   'Prompt to generate response from.'
@@ -325,6 +353,18 @@ class Message(SubscriptableBaseModel):
   - `bytes` or bytes-like object: raw image data
 
   Valid image formats depend on the model. See the model card for more information.
+  """
+
+  audio: Optional[Sequence[Audio]] = None
+  """
+  Optional list of audio data for multimodal models.
+
+  Valid input types are:
+
+  - `str` or path-like object: path to audio file
+  - `bytes` or bytes-like object: raw audio data
+
+  Valid audio formats depend on the model. See the model card for more information.
   """
 
   tool_name: Optional[str] = None


### PR DESCRIPTION
## Summary

Adds a dedicated `Audio` class and `audio` field to `Message`, mirroring the existing `Image` pattern.

Closes #650

## Motivation

Currently, audio data must be passed via the `images` key, which is confusing and blocks future models that support both images *and* audio simultaneously. This PR adds a first-class `audio` field so callers can pass audio data cleanly:

```python
ollama.chat(
    model="gemma4:e2b",
    messages=[{
        "role": "user",
        "content": "Transcribe this",
        "audio": ["recording.wav"],   # clear, not crammed into images
    }]
)
```

## Changes

**`ollama/_types.py`**

- Added `Audio(BaseModel)` class after `Image`, with identical serialisation logic:
  - `Path` / `bytes` → base64-encodes the data
  - `str` path that exists on disk → base64-encodes the file
  - `str` with a known audio extension that doesn't exist → raises `ValueError` with a clear message
  - `str` that looks like existing base64 → passes through
  - Unknown string → raises `ValueError`
  - Supported extension check covers: `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, `webm`

- Added `audio: Optional[Sequence[Audio]] = None` field to `Message` (after `images`), with the same docstring style as `images`.

## Compatibility

- No breaking changes — `audio` is optional and defaults to `None`
- The serialisation behaviour is consistent with `Image`, so the wire format is already what the Ollama server expects (raw base64)
