### PR TITLE
docs(examples): add logprobs section to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,11 @@ See [ollama/docs/api.md](https://github.com/ollama/ollama/blob/main/docs/api.md)
 - [generate-stream.py](generate-stream.py) - Streamed outputs
 - [fill-in-middle.py](fill-in-middle.py) - Given a prefix and suffix, fill in the middle
 
+### Logprobs - Inspect token probabilities
+
+- [chat-logprobs.py](chat-logprobs.py) - Chat with logprobs and top alternatives
+- [generate-logprobs.py](generate-logprobs.py) - Generate with logprobs and top alternatives
+
 ### Tools/Function Calling - Call a function with a model
 
 - [tools.py](tools.py) - Simple example of Tools/Function Calling


### PR DESCRIPTION
## Summary

The examples directory contains `chat-logprobs.py` and `generate-logprobs.py`, but `examples/README.md` does not list them. Users browsing the index cannot discover these examples without scanning the directory directly.

This PR adds a small "Logprobs" section to `examples/README.md` so the two existing example files appear alongside the other categories (Chat, Generate, Tools, etc.).

## Why

- `chat-logprobs.py` and `generate-logprobs.py` are already in the repo (the underlying `logprobs`/`top_logprobs` API surface is supported in `_types.py`).
- The README is the canonical entry point for example discovery.
- Issue #517 ("Is logprobs supported in chat()?") indicates user demand for clearer logprobs documentation.

## Changes

- `examples/README.md`: add a single 3-line section under Generate that links to both files.

No code changes. Pure docs fix.

## How to test

- Open `examples/README.md` and confirm the new "Logprobs - Inspect token probabilities" section renders between "Generate" and "Tools/Function Calling".
- Confirm both relative links (`chat-logprobs.py`, `generate-logprobs.py`) resolve.