### PR TITLE
feat: add explicit __enter__ and __aenter__ to BaseClient

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -117,10 +117,16 @@ class BaseClient(contextlib.AbstractContextManager, contextlib.AbstractAsyncCont
       **kwargs,
     )
 
-  def __exit__(self, exc_type, exc_val, exc_tb):
+  def __enter__(self) -> "BaseClient":
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb) -> None:
     self.close()
 
-  async def __aexit__(self, exc_type, exc_val, exc_tb):
+  async def __aenter__(self) -> "BaseClient":
+    return self
+
+  async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
     await self.close()
 
 


### PR DESCRIPTION
Fixes #642

## Problem

`async with AsyncClient() as c:` raises `TypeError` at runtime:

```
TypeError: object AsyncClient can't be used in 'async with' statement
```

`BaseClient` inherits `AbstractContextManager` and `AbstractAsyncContextManager` but only defined `__exit__` and `__aexit__`. `AbstractContextManager` provides a default `__enter__` returning `self`, but `AbstractAsyncContextManager.__aenter__` is abstract and raises `TypeError` if not implemented.

## Fix

Add explicit `__enter__` and `__aenter__` methods to `BaseClient`, both returning `self`, completing the context manager protocol for both sync and async clients.

## Usage after this change

```python
# Sync
with Client() as client:
    response = client.chat(...)

# Async
async with AsyncClient() as client:
    response = await client.chat(...)
```

## Notes

- No behaviour change to `__exit__` / `__aexit__` — they still call `close()` / `await close()` as before.
- `Client.__enter__` returns `BaseClient` — callers using the context manager with type annotations may want to cast to `Client` / `AsyncClient` if needed. A follow-up could tighten the return type using generics.