### PR TITLE
fix: add missing default=None to modelinfo field in ShowResponse

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -572,7 +572,7 @@ class ShowResponse(SubscriptableBaseModel):
 
   details: Optional[ModelDetails] = None
 
-  modelinfo: Optional[Mapping[str, Any]] = Field(alias='model_info')
+  modelinfo: Optional[Mapping[str, Any]] = Field(default=None, alias='model_info')
 
   parameters: Optional[str] = None
 


### PR DESCRIPTION
## Problem

`modelinfo` was declared `Optional[Mapping[str, Any]]` but the `Field()` call had no `default` argument:

```python
modelinfo: Optional[Mapping[str, Any]] = Field(alias="model_info")
```

In Pydantic v2, `Optional` alone does not provide a default — the field is required. If an Ollama server response omits `model_info` (e.g. older server versions), Pydantic raises `ValidationError`.

Every other `Optional` field in `ShowResponse` explicitly sets `= None`.

## Fix

Add `default=None` to the Field call.