### PR TITLE
fix(examples): replace deprecated datetime.utcnow() in web_search_gpt_oss_helper

### DIFF
--- a/examples/web_search_gpt_oss_helper.py
+++ b/examples/web_search_gpt_oss_helper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 from urllib.parse import urlparse
 
@@ -212,7 +212,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     tb = []
@@ -246,7 +246,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     link_fmt = f'【{link_idx}†{result.title}】\n'
@@ -275,7 +275,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     for url, url_results in fetch_response.get('results', {}).items():
@@ -306,7 +306,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     max_results = 50
@@ -442,7 +442,7 @@ class Browser:
           text='',
           lines=[],
           links={},
-          fetched_at=datetime.utcnow(),
+          fetched_at=datetime.now(timezone.utc),
         )
         available = sorted(page.links.keys())
         available_list = ', '.join(map(str, available)) if available else '(none)'


### PR DESCRIPTION
## What

`datetime.utcnow()` is deprecated since Python 3.12 and emits a `DeprecationWarning` whenever the helper is imported under a strict warnings config. The recommended replacement is `datetime.now(timezone.utc)`, which also returns a timezone-aware UTC datetime instead of the naive one `utcnow()` produces — a small correctness win, since naive UTC datetimes can silently misbehave when compared against aware ones elsewhere in user code.

## Why

- Removes Python 3.12+ `DeprecationWarning` from the example.
- Returns aware UTC datetimes, which is the modern Python recommendation.
- Behaviour-equivalent for the example's downstream use: `fetched_at: datetime` accepts both naive and aware values.

## Changes

`examples/web_search_gpt_oss_helper.py`:

- Add `timezone` to the existing `from datetime import datetime` import.
- Replace 5 occurrences of `datetime.utcnow()` with `datetime.now(timezone.utc)`.

Total: +6/-6 lines, 1 file.

## Testing

Pure call-site swap with no logic change. The file parses cleanly (`python -m py_compile`). The example still produces the same wall-clock instant for `fetched_at`, just with a `tzinfo=UTC` attached instead of `None`.