### PR TITLE
fix: use timezone-aware UTC in web search example

### DIFF
--- a/examples/web_search_gpt_oss_helper.py
+++ b/examples/web_search_gpt_oss_helper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 from urllib.parse import urlparse
 
@@ -212,7 +212,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     tb = []
@@ -246,7 +246,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     link_fmt = f'【{link_idx}†{result.title}】\n'
@@ -275,7 +275,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     for url, url_results in fetch_response.get('results', {}).items():
@@ -306,7 +306,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     max_results = 50
@@ -442,7 +442,7 @@ class Browser:
           text='',
           lines=[],
           links={},
-          fetched_at=datetime.utcnow(),
+          fetched_at=datetime.now(timezone.utc),
         )
         available = sorted(page.links.keys())
         available_list = ', '.join(map(str, available)) if available else '(none)'


### PR DESCRIPTION
## Summary

Replace `datetime.utcnow()` in `examples/web_search_gpt_oss_helper.py` with `datetime.now(timezone.utc)`.

## Bug

The example helper builds `Page.fetched_at` timestamps with `datetime.utcnow()`, which is deprecated in Python 3.12 because it returns a naive datetime. Running the example on Python 3.12+ can emit deprecation warnings.

## Before/After

Before:
```python
fetched_at=datetime.utcnow()
```

After:
```python
fetched_at=datetime.now(timezone.utc)
```

The value is still UTC, but now it is explicitly timezone-aware.

## Verification

- `python -m compileall -q examples/web_search_gpt_oss_helper.py`
- `git diff --check`
- `rg -n 'datetime\.utcnow\(' examples/web_search_gpt_oss_helper.py` returns no matches