### PR TITLE
feat: add exists() method and fix ShowResponse for cloud models (clos…

### DIFF
--- a/ollama/__init__.py
+++ b/ollama/__init__.py
@@ -54,6 +54,7 @@ delete = _client.delete
 list = _client.list
 copy = _client.copy
 show = _client.show
+exists = _client.exists
 ps = _client.ps
 web_search = _client.web_search
 web_fetch = _client.web_fetch

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -664,6 +664,28 @@ class Client(BaseClient):
       ).model_dump(exclude_none=True),
     )
 
+
+  def exists(self, model: str) -> bool:
+    """
+    Check whether a model is available locally.
+
+    Args:
+      model: Name of the model to check (e.g. 'llama3.2' or 'llama3.2:latest').
+
+    Returns:
+      True if the model is present locally, False otherwise.
+
+    Example::
+
+      if not client.exists('llama3.2'):
+          client.pull('llama3.2')
+    """
+    try:
+      self.show(model)
+      return True
+    except ResponseError:
+      return False
+
   def ps(self) -> ProcessResponse:
     return self._request(
       ProcessResponse,
@@ -1304,6 +1326,28 @@ class AsyncClient(BaseClient):
         model=model,
       ).model_dump(exclude_none=True),
     )
+
+
+  async def exists(self, model: str) -> bool:
+    """
+    Check whether a model is available locally.
+
+    Args:
+      model: Name of the model to check (e.g. 'llama3.2' or 'llama3.2:latest').
+
+    Returns:
+      True if the model is present locally, False otherwise.
+
+    Example::
+
+      if not await client.exists('llama3.2'):
+          await client.pull('llama3.2')
+    """
+    try:
+      await self.show(model)
+      return True
+    except ResponseError:
+      return False
 
   async def ps(self) -> ProcessResponse:
     return await self._request(

--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -572,7 +572,8 @@ class ShowResponse(SubscriptableBaseModel):
 
   details: Optional[ModelDetails] = None
 
-  modelinfo: Optional[Mapping[str, Any]] = Field(alias='model_info')
+  modelinfo: Optional[Mapping[str, Any]] = Field(default=None, alias='model_info')
+  'Per-model metadata. Absent for some cloud models.'
 
   parameters: Optional[str] = None
 


### PR DESCRIPTION
…es #640, closes #607)
Closes #640
Closes #607

## Changes

### New: `ollama.exists(model)` 
A clean boolean check for whether a model is available locally — 
no more catching exceptions for control flow.

```python
# Before (ugly)
try:
    ollama.show("llama3.2")
except ollama.ResponseError:
    ollama.pull("llama3.2")

# After (clean)
if not ollama.exists("llama3.2"):
    ollama.pull("llama3.2")
```

Available on both `Client` and `AsyncClient`.

### Bug fix: `ShowResponse` crash on cloud models (#607)
`model_info` was declared as required by Pydantic even though it was 
typed `Optional`. Cloud models like `glm-4.7:cloud` don't return 
`model_info`, causing a hard `ValidationError`. Fixed by adding 
`default=None`.