### PR TITLE
fix: use delete=False for NamedTemporaryFile in tests on Windows

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -466,6 +466,11 @@ def test_client_generate_images(httpserver: HTTPServer):
     response = client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
     assert response['model'] == 'dummy'
     assert response['response'] == 'Because it is.'
+  
+  try:
+    os.remove(temp.name)
+  except FileNotFoundError:
+    pass
 
 
 def test_client_generate_format_json(httpserver: HTTPServer):
@@ -854,6 +859,11 @@ def test_client_create_blob(httpserver: HTTPServer):
     response = client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
+  try:
+    os.remove(blob.name)
+  except FileNotFoundError:
+    pass
+
 
 def test_client_create_blob_exists(httpserver: HTTPServer):
   httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='POST').respond_with_response(Response(status=200))
@@ -863,6 +873,11 @@ def test_client_create_blob_exists(httpserver: HTTPServer):
   with tempfile.NamedTemporaryFile(delete=False) as blob:
     response = client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  
+  try:
+    os.remove(blob.name)
+  except FileNotFoundError:
+    pass
 
 
 def test_client_delete(httpserver: HTTPServer):
@@ -1062,6 +1077,10 @@ async def test_async_client_generate_images(httpserver: HTTPServer):
     assert response['model'] == 'dummy'
     assert response['response'] == 'Because it is.'
 
+  try:
+    os.remove(temp.name)
+  except FileNotFoundError:
+    pass
 
 async def test_async_client_pull(httpserver: HTTPServer):
   httpserver.expect_ordered_request(
@@ -1231,6 +1250,10 @@ async def test_async_client_create_blob(httpserver: HTTPServer):
     response = await client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
+  try:
+    os.remove(blob.name)
+  except FileNotFoundError:
+    pass
 
 async def test_async_client_create_blob_exists(httpserver: HTTPServer):
   httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='POST').respond_with_response(Response(status=200))
@@ -1240,7 +1263,11 @@ async def test_async_client_create_blob_exists(httpserver: HTTPServer):
   with tempfile.NamedTemporaryFile(delete=False) as blob:
     response = await client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-
+  
+  try:
+    os.remove(blob.name)
+  except FileNotFoundError:
+    pass
 
 async def test_async_client_delete(httpserver: HTTPServer):
   httpserver.expect_ordered_request(PrefixPattern('/api/delete'), method='DELETE').respond_with_response(Response(status=200))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -460,7 +460,7 @@ def test_client_generate_images(httpserver: HTTPServer):
 
   client = Client(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as temp:
+  with tempfile.NamedTemporaryFile(delete=False) as temp:
     temp.write(PNG_BYTES)
     temp.flush()
     response = client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
@@ -850,7 +850,7 @@ def test_client_create_blob(httpserver: HTTPServer):
 
   client = Client(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as blob:
+  with tempfile.NamedTemporaryFile(delete=False) as blob:
     response = client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -860,7 +860,7 @@ def test_client_create_blob_exists(httpserver: HTTPServer):
 
   client = Client(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as blob:
+  with tempfile.NamedTemporaryFile(delete=False) as blob:
     response = client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -1055,7 +1055,7 @@ async def test_async_client_generate_images(httpserver: HTTPServer):
 
   client = AsyncClient(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as temp:
+  with tempfile.NamedTemporaryFile(delete=False) as temp:
     temp.write(PNG_BYTES)
     temp.flush()
     response = await client.generate('dummy', 'Why is the sky blue?', images=[temp.name])
@@ -1227,7 +1227,7 @@ async def test_async_client_create_blob(httpserver: HTTPServer):
 
   client = AsyncClient(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as blob:
+  with tempfile.NamedTemporaryFile(delete=False) as blob:
     response = await client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -1237,7 +1237,7 @@ async def test_async_client_create_blob_exists(httpserver: HTTPServer):
 
   client = AsyncClient(httpserver.url_for('/'))
 
-  with tempfile.NamedTemporaryFile() as blob:
+  with tempfile.NamedTemporaryFile(delete=False) as blob:
     response = await client.create_blob(blob.name)
     assert response == 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -32,7 +32,7 @@ def test_image_serialization_plain_string():
 
 
 def test_image_serialization_path():
-  with tempfile.NamedTemporaryFile() as temp_file:
+  with tempfile.NamedTemporaryFile(delete=False) as temp_file:
     temp_file.write(b'test file content')
     temp_file.flush()
     img = Image(value=Path(temp_file.name))
@@ -40,7 +40,7 @@ def test_image_serialization_path():
 
 
 def test_image_serialization_string_path():
-  with tempfile.NamedTemporaryFile() as temp_file:
+  with tempfile.NamedTemporaryFile(delete=False) as temp_file:
     temp_file.write(b'test file content')
     temp_file.flush()
     img = Image(value=temp_file.name)

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -1,4 +1,5 @@
 import tempfile
+import os
 from base64 import b64encode
 from pathlib import Path
 
@@ -38,6 +39,11 @@ def test_image_serialization_path():
     img = Image(value=Path(temp_file.name))
     assert img.model_dump() == b64encode(b'test file content').decode()
 
+  try:
+    os.remove(temp_file.name)
+  except FileNotFoundError:
+    pass
+
 
 def test_image_serialization_string_path():
   with tempfile.NamedTemporaryFile(delete=False) as temp_file:
@@ -46,6 +52,11 @@ def test_image_serialization_string_path():
     img = Image(value=temp_file.name)
     assert img.model_dump() == b64encode(b'test file content').decode()
 
+  try:
+    os.remove(temp_file.name)
+  except FileNotFoundError:
+    pass
+  
   with pytest.raises(ValueError):
     img = Image(value='some_path/that/does/not/exist.png')
     img.model_dump()


### PR DESCRIPTION
Fixes #676  tests failing on Windows due to NamedTemporaryFile locking.

On Windows, NamedTemporaryFile locks the file while open, causing
PermissionError when the code tries to read it. Adding delete=False
resolves this.

Fixes: 8 failing tests on Windows
- test_client_generate_images
- test_client_create_blob
- test_client_create_blob_exists
- test_async_client_generate_images
- test_async_client_create_blob
- test_async_client_create_blob_exists
- test_image_serialization_path
- test_image_serialization_string_path


