### PR TITLE
add async-thinking example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -123,6 +123,7 @@ Requirement: `pip install tqdm`
 ### Thinking (generate) - Enable thinking mode for a model
 
 - [thinking-generate.py](thinking-generate.py)
+- [async-thinking.py](async-thinking.py)
 
 ### Thinking (levels) - Choose the thinking level
 

--- a/examples/async-thinking.py
+++ b/examples/async-thinking.py
@@ -1,0 +1,22 @@
+import asyncio
+
+from ollama import AsyncClient
+
+
+async def main():
+  messages = [
+    {
+      'role': 'user',
+      'content': 'How many r letters are in the word strawberry?',
+    },
+  ]
+
+  client = AsyncClient()
+  response = await client.chat('deepseek-r1', messages=messages, think=True)
+
+  print('Thinking:\n========\n\n' + response.message.thinking)
+  print('\nResponse:\n========\n\n' + response.message.content)
+
+
+if __name__ == '__main__':
+  asyncio.run(main())


### PR DESCRIPTION
Adds `async-thinking.py` to the examples folder — the async equivalent
of the existing `thinking.py`.

This follows the same pattern used by the other async examples:
- `async-chat.py` mirrors `chat.py`
- `async-generate.py` mirrors `generate.py`
- `async-tools.py` mirrors `tools.py`

Also updates `examples/README.md` to list the new example.