### PR TITLE
added max option to think parameter

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -207,7 +207,7 @@ class GenerateRequest(BaseGenerateRequest):
   images: Optional[Sequence[Image]] = None
   'Image data for multimodal models.'
 
-  think: Optional[Union[bool, Literal['low', 'medium', 'high']]] = None
+  think: Optional[Union[bool, Literal['low', 'medium', 'high', 'max']]] = None
   'Enable thinking mode (for thinking models).'
 
   logprobs: Optional[bool] = None
@@ -400,7 +400,7 @@ class ChatRequest(BaseGenerateRequest):
   tools: Optional[Sequence[Tool]] = None
   'Tools to use for the chat.'
 
-  think: Optional[Union[bool, Literal['low', 'medium', 'high']]] = None
+  think: Optional[Union[bool, Literal['low', 'medium', 'high', 'max']]] = None
   'Enable thinking mode (for thinking models).'
 
   logprobs: Optional[bool] = None


### PR DESCRIPTION
This adds `max` as an accepted value for the `think` parameter in the Python SDK.

The Ollama API/CLI supports max thinking effort for supported models, but the Python SDK type definitions currently allow only `low`, `medium`, and `high`.

This change updates the existing `Literal[...]` annotations to include `max` and adds tests to confirm it is serialized as top-level `think: "max"`.