### PR TITLE
Do not add default ports for explicit hosts

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1353,9 +1353,9 @@ def _parse_host(host: Optional[str]) -> str:
   >>> _parse_host('1.2.3.4:56789')
   'http://1.2.3.4:56789'
   >>> _parse_host('http://1.2.3.4')
-  'http://1.2.3.4:80'
+  'http://1.2.3.4'
   >>> _parse_host('https://1.2.3.4')
-  'https://1.2.3.4:443'
+  'https://1.2.3.4'
   >>> _parse_host('https://1.2.3.4:56789')
   'https://1.2.3.4:56789'
   >>> _parse_host('example.com')
@@ -1363,9 +1363,9 @@ def _parse_host(host: Optional[str]) -> str:
   >>> _parse_host('example.com:56789')
   'http://example.com:56789'
   >>> _parse_host('http://example.com')
-  'http://example.com:80'
+  'http://example.com'
   >>> _parse_host('https://example.com')
-  'https://example.com:443'
+  'https://example.com'
   >>> _parse_host('https://example.com:56789')
   'https://example.com:56789'
   >>> _parse_host('example.com/')
@@ -1378,6 +1378,8 @@ def _parse_host(host: Optional[str]) -> str:
   'http://example.com:56789/path'
   >>> _parse_host('https://example.com:56789/path')
   'https://example.com:56789/path'
+  >>> _parse_host('https://example.com/path')
+  'https://example.com/path'
   >>> _parse_host('example.com:56789/path/')
   'http://example.com:56789/path'
   >>> _parse_host('[0001:002:003:0004::1]')
@@ -1385,9 +1387,9 @@ def _parse_host(host: Optional[str]) -> str:
   >>> _parse_host('[0001:002:003:0004::1]:56789')
   'http://[0001:002:003:0004::1]:56789'
   >>> _parse_host('http://[0001:002:003:0004::1]')
-  'http://[0001:002:003:0004::1]:80'
+  'http://[0001:002:003:0004::1]'
   >>> _parse_host('https://[0001:002:003:0004::1]')
-  'https://[0001:002:003:0004::1]:443'
+  'https://[0001:002:003:0004::1]'
   >>> _parse_host('https://[0001:002:003:0004::1]:56789')
   'https://[0001:002:003:0004::1]:56789'
   >>> _parse_host('[0001:002:003:0004::1]/')
@@ -1400,22 +1402,21 @@ def _parse_host(host: Optional[str]) -> str:
   'http://[0001:002:003:0004::1]:56789/path'
   >>> _parse_host('https://[0001:002:003:0004::1]:56789/path')
   'https://[0001:002:003:0004::1]:56789/path'
+  >>> _parse_host('https://[0001:002:003:0004::1]/path')
+  'https://[0001:002:003:0004::1]/path'
   >>> _parse_host('[0001:002:003:0004::1]:56789/path/')
   'http://[0001:002:003:0004::1]:56789/path'
   """
 
-  host, port = host or '', 11434
+  host, default_port = host or '', 11434
   scheme, _, hostport = host.partition('://')
+  has_scheme = bool(hostport)
   if not hostport:
     scheme, hostport = 'http', host
-  elif scheme == 'http':
-    port = 80
-  elif scheme == 'https':
-    port = 443
 
   split = urllib.parse.urlsplit(f'{scheme}://{hostport}')
   host = split.hostname or '127.0.0.1'
-  port = split.port or port
+  port = split.port
 
   try:
     if isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address):
@@ -1425,6 +1426,18 @@ def _parse_host(host: Optional[str]) -> str:
     ...
 
   if path := split.path.strip('/'):
+    if port is None:
+      if has_scheme:
+        return f'{scheme}://{host}/{path}'
+
+      port = default_port
+
     return f'{scheme}://{host}:{port}/{path}'
+
+  if port is None:
+    if has_scheme:
+      return f'{scheme}://{host}'
+
+    port = default_port
 
   return f'{scheme}://{host}:{port}'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from pytest_httpserver import HTTPServer, URIPattern
 from werkzeug.wrappers import Request, Response
 
-from ollama._client import CONNECTION_ERROR_MESSAGE, AsyncClient, Client, _copy_tools
+from ollama._client import CONNECTION_ERROR_MESSAGE, AsyncClient, Client, _copy_tools, _parse_host
 from ollama._types import Image, Message
 
 PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'
@@ -24,6 +24,22 @@ pytestmark = pytest.mark.anyio
 @pytest.fixture
 def anyio_backend():
   return 'asyncio'
+
+
+@pytest.mark.parametrize(
+  ('host', 'expected'),
+  [
+    ('example.com', 'http://example.com:11434'),
+    ('http://example.com', 'http://example.com'),
+    ('https://example.com', 'https://example.com'),
+    ('https://example.com/path', 'https://example.com/path'),
+    ('http://[0001:002:003:0004::1]', 'http://[0001:002:003:0004::1]'),
+    ('https://[0001:002:003:0004::1]', 'https://[0001:002:003:0004::1]'),
+    ('https://[0001:002:003:0004::1]/path', 'https://[0001:002:003:0004::1]/path'),
+  ],
+)
+def test_parse_host_default_ports(host: str, expected: str):
+  assert _parse_host(host) == expected
 
 
 class PrefixPattern(URIPattern):


### PR DESCRIPTION
## Summary
Stop `_parse_host` from appending `:80` or `:443` when the input already includes an explicit `http://` or `https://` scheme without a port.

## Motivation
When callers configure a custom host such as `https://example.com`, the client currently normalizes it to `https://example.com:443`. That changes the visible configured host and can be problematic for reverse proxies or environments that expect the default port to remain implicit.

Fixes #222

## Changes
- Track whether the input included an explicit scheme.
- Preserve the existing Ollama default port `:11434` for bare hosts.
- Avoid adding default HTTP/HTTPS ports for explicit scheme hosts without a port.
- Add doctest examples and a parametrized regression test.

## Testing
- `uv run --with pytest --with pytest-anyio --with pytest-httpserver pytest tests/test_client.py::test_parse_host_default_ports --doctest-modules ollama/_client.py` → `8 passed in 0.64s`
- `uv run --with pytest --with pytest-anyio --with pytest-httpserver pytest tests/test_client.py::test_parse_host_default_ports --doctest-modules ollama/_client.py tests/test_client.py` → `80 passed in 3.29s`
- `uv run --with ruff ruff check ollama/_client.py tests/test_client.py` → `All checks passed!`
- `git diff --check`
- Secret scan on diff: clean