### PR TITLE
fix: preserve empty chat message fields

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1321,7 +1321,7 @@ def _copy_images(images: Optional[Sequence[Union[Image, Any]]]) -> Iterator[Imag
 def _copy_messages(messages: Optional[Sequence[Union[Mapping[str, Any], Message]]]) -> Iterator[Message]:
   for message in messages or []:
     yield Message.model_validate(
-      {k: list(_copy_images(v)) if k == 'images' else v for k, v in dict(message).items() if v},
+      {k: list(_copy_images(v)) if k == 'images' else v for k, v in dict(message).items() if v is not None},
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,6 +61,31 @@ def test_client_chat(httpserver: HTTPServer):
   assert response['message']['content'] == "I don't know."
 
 
+def test_client_chat_preserves_empty_message_content(httpserver: HTTPServer):
+  httpserver.expect_ordered_request(
+    '/api/chat',
+    method='POST',
+    json={
+      'model': 'dummy',
+      'messages': [{'role': 'user', 'content': ''}],
+      'tools': [],
+      'stream': False,
+    },
+  ).respond_with_json(
+    {
+      'model': 'dummy',
+      'message': {
+        'role': 'assistant',
+        'content': 'empty received',
+      },
+    }
+  )
+
+  client = Client(httpserver.url_for('/'))
+  response = client.chat('dummy', messages=[{'role': 'user', 'content': ''}])
+  assert response['message']['content'] == 'empty received'
+
+
 def test_client_chat_with_logprobs(httpserver: HTTPServer):
   httpserver.expect_ordered_request(
     '/api/chat',


### PR DESCRIPTION
### Summary
- Preserve empty string and other falsy-but-valid chat message fields when normalizing messages.
- Continue dropping only fields whose value is `None`.

### Why
An explicitly empty `content` field is valid input in some chat/tool-call flows, but `_copy_messages()` previously removed it because it filtered on truthiness.

### Testing
- `python -m pytest tests/test_client.py::test_client_chat_preserves_empty_message_content tests/test_client.py::test_client_chat -q`
- `git diff --check`