### PR TITLE
fix: preserve non-object response error bodies

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -638,7 +638,9 @@ class ResponseError(Exception):
     # try to parse content as JSON and extract 'error'
     # fallback to raw content if JSON parsing fails
     with contextlib.suppress(json.JSONDecodeError):
-      error = json.loads(error).get('error', error)
+      parsed_error = json.loads(error)
+      if isinstance(parsed_error, dict):
+        error = parsed_error.get('error', error)
 
     super().__init__(error)
     self.error = error

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from ollama._types import CreateRequest, Image
+from ollama._types import CreateRequest, Image, ResponseError
 
 
 def test_image_serialization_bytes():
@@ -92,3 +92,15 @@ def test_create_request_serialization_license_list():
   request = CreateRequest(model='test-model', license=['MIT', 'Apache-2.0'])
   serialized = request.model_dump()
   assert serialized['license'] == ['MIT', 'Apache-2.0']
+
+
+def test_response_error_uses_json_object_error_field():
+  error = ResponseError('{"error": "model not found"}', 404)
+  assert error.error == 'model not found'
+  assert str(error) == 'model not found (status code: 404)'
+
+
+def test_response_error_preserves_non_object_json_body():
+  error = ResponseError('"server unavailable"', 503)
+  assert error.error == '"server unavailable"'
+  assert str(error) == '"server unavailable" (status code: 503)'


### PR DESCRIPTION
### Summary
- Only read the `error` field from JSON object error responses.
- Preserve non-object JSON error bodies instead of raising a constructor-time exception.

### Why
`ResponseError` currently assumes any decoded JSON response is a dictionary. JSON strings, arrays, or numbers are valid response bodies and should still produce a useful `ResponseError`.

### Testing
- `python -m pytest tests/test_type_serialization.py::test_response_error_uses_json_object_error_field tests/test_type_serialization.py::test_response_error_preserves_non_object_json_body -q`
- `git diff --check`