### PR TITLE
fix: strip whitespace from host values

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -1404,7 +1404,7 @@ def _parse_host(host: Optional[str]) -> str:
   'http://[0001:002:003:0004::1]:56789/path'
   """
 
-  host, port = host or '', 11434
+  host, port = (host or '').strip(), 11434
   scheme, _, hostport = host.partition('://')
   if not hostport:
     scheme, hostport = 'http', host

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from pytest_httpserver import HTTPServer, URIPattern
 from werkzeug.wrappers import Request, Response
 
-from ollama._client import CONNECTION_ERROR_MESSAGE, AsyncClient, Client, _copy_tools
+from ollama._client import CONNECTION_ERROR_MESSAGE, AsyncClient, Client, _copy_tools, _parse_host
 from ollama._types import Image, Message
 
 PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'
@@ -1322,6 +1322,12 @@ def test_tool_validation():
   assert len(tools) == 1
   assert tools[0].type == 'custom_type'
   assert tools[0].function.name == 'test'
+
+
+def test_parse_host_strips_whitespace():
+  assert _parse_host(' http://example.com ') == 'http://example.com:80'
+  assert _parse_host(' example.com:56789 ') == 'http://example.com:56789'
+  assert _parse_host('\thttps://example.com/path\n') == 'https://example.com:443/path'
 
 
 def test_client_connection_error():


### PR DESCRIPTION
### Summary
- Strip leading and trailing whitespace before parsing explicit host values.
- Cover host strings with schemes, ports, and paths.

### Why
Values copied into `OLLAMA_HOST` or passed as a host argument can include surrounding whitespace. Without trimming, host parsing can produce an invalid base URL or raise while parsing the port.

### Testing
- `python -m pytest tests/test_client.py::test_parse_host_strips_whitespace tests/test_client.py::test_headers -q`
- `git diff --check`