### PR TITLE
fix(example): use aware web search timestamps

### DIFF
--- a/examples/web_search_gpt_oss_helper.py
+++ b/examples/web_search_gpt_oss_helper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 from urllib.parse import urlparse
 
@@ -212,7 +212,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     tb = []
@@ -246,7 +246,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     link_fmt = f'【{link_idx}†{result.title}】\n'
@@ -275,7 +275,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     for url, url_results in fetch_response.get('results', {}).items():
@@ -306,7 +306,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     max_results = 50
@@ -442,7 +442,7 @@ class Browser:
           text='',
           lines=[],
           links={},
-          fetched_at=datetime.utcnow(),
+          fetched_at=datetime.now(timezone.utc),
         )
         available = sorted(page.links.keys())
         available_list = ', '.join(map(str, available)) if available else '(none)'


### PR DESCRIPTION
## Summary
- replace `datetime.utcnow()` in the GPT-OSS web search helper example with `datetime.now(timezone.utc)`
- keep the existing `Page.fetched_at` type and behavior while making timestamps timezone-aware

## Problem
The example currently creates fetched-at timestamps with naive UTC datetimes. `datetime.utcnow()` is deprecated in modern Python, and the resulting values do not carry explicit timezone information.

## Before / After
Before, fetched pages stored naive UTC timestamps.

After, fetched pages store UTC-aware timestamps with `timezone.utc`.

## Verification
- `python -m py_compile examples/web_search_gpt_oss_helper.py`
- `git diff --check`
