### PR TITLE
fix(utils): emit multi-type tool params as JSON array, not a comma-joined string

### DIFF
--- a/ollama/_utils.py
+++ b/ollama/_utils.py
@@ -73,9 +73,14 @@ def convert_function_to_tool(func: Callable) -> Tool:
       schema['required'].remove(k)
       types.discard('null')
 
+    # Emit a single type as a string and multiple types as a JSON-Schema array.
+    # A comma-joined string (e.g. 'integer, string') is parsed by the server as one
+    # invalid type name, silently dropping the constraint. Sorting also makes the
+    # output deterministic across runs since types is a set.
+    sorted_types = sorted(types)
     schema['properties'][k] = {
       'description': parsed_docstring[k],
-      'type': ', '.join(types),
+      'type': sorted_types if len(sorted_types) > 1 else ''.join(sorted_types),
     }
 
   tool = Tool(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,8 +98,10 @@ def test_function_with_all_types():
   if sys.version_info >= (3, 10):
     assert tool['function']['parameters']['properties']['z']['type'] == 'array'
     assert tool['function']['parameters']['properties']['w']['type'] == 'object'
-    assert {x.strip().strip("'") for x in tool['function']['parameters']['properties']['v']['type'].removeprefix('[').removesuffix(']').split(',')} == {'string', 'integer'}
-    assert tool['function']['parameters']['properties']['v']['type'] != 'null'
+    # A multi-type parameter must be a JSON array, not a comma-joined string, so the
+    # server parses each type instead of one invalid 'integer, string' type name.
+    assert isinstance(tool['function']['parameters']['properties']['v']['type'], list)
+    assert tool['function']['parameters']['properties']['v']['type'] == ['integer', 'string']
     assert tool['function']['parameters']['required'] == ['x', 'y', 'z', 'w']
   else:
     assert tool['function']['parameters']['properties']['z']['type'] == 'array'


### PR DESCRIPTION

### What

`convert_function_to_tool` serializes a tool parameter that has more than one type
(for example `int | str`) as the comma-joined string `'integer, string'` instead of
the JSON-Schema array `['integer', 'string']`.

### Why this is a bug

The generated `type` string is not valid JSON Schema. The Ollama server parses a
parameter `type` that is a JSON string as a single type name, so `'integer, string'`
is read as one (nonexistent) type and the multi-type constraint is silently dropped.
The array form is the shape the schema expects: `Tool.Function.Parameters.Property.type`
is `Optional[Union[str, Sequence[str]]]` (`ollama/_types.py`), and an array is already
used as the canonical multi-type input elsewhere in the tests
(`tests/test_client.py`, `'type': ['integer', 'number']`).

There is also a non-determinism bug: `types` is built as a `set`, so the same
function could serialize to `'integer, string'` on one run and `'string, integer'`
on the next.

### Fix

In `ollama/_utils.py`, sort the `types` set and emit:

- a single type as a bare string (unchanged behavior), and
- multiple types as a sorted list (a real JSON array).

Sorting also makes the output deterministic. The empty-`types` edge case (a
parameter typed only `None`) keeps its prior `''` output via `''.join([])`.

```python
sorted_types = sorted(types)
schema['properties'][k] = {
  'description': parsed_docstring[k],
  'type': sorted_types if len(sorted_types) > 1 else ''.join(sorted_types),
}
```

### Tests

Updated `tests/test_utils.py::test_function_with_all_types` so the multi-type
parameter (`v: int | str | None` on Python >= 3.10) is asserted to be a JSON array:

```python
assert isinstance(tool['function']['parameters']['properties']['v']['type'], list)
assert tool['function']['parameters']['properties']['v']['type'] == ['integer', 'string']
```

This replaces the previous fragile string-parsing assertion (which stripped
brackets and split on commas). The new assertion fails on the old comma-joined
string and passes with the fix.

Verified locally:

- `uv run pytest ollama tests -q` -> 97 passed (doctests included)
- `uvx hatch fmt --check -f` (format) and `uvx hatch fmt --check -l` (lint) -> pass
- `uv lock --check` -> ok; `uv export` vs `requirements.txt` -> no diff

Single-type parameters (e.g. `x: int` -> `'integer'`) are unaffected.
