### PR TITLE
types: make Image path extension check case-insensitive

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -175,7 +175,7 @@ class Image(BaseModel):
         pass
 
       # String might be a file path, but might not exist
-      if self.value.split('.')[-1] in ('png', 'jpg', 'jpeg', 'webp'):
+      if self.value.split('.')[-1].lower() in ('png', 'jpg', 'jpeg', 'webp'):
         raise ValueError(f'File {self.value} does not exist')
 
       try:

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -55,6 +55,19 @@ def test_image_serialization_string_path():
     img.model_dump()
 
 
+@pytest.mark.parametrize('extension', ['PNG', 'JPG', 'JPEG', 'WEBP'])
+def test_image_serialization_string_path_uppercase_extension(extension):
+  # A non-existent path with an uppercase image extension must be rejected the
+  # same way its lowercase counterpart is, rather than being treated as base64.
+  with pytest.raises(ValueError, match='does not exist'):
+    Image(value=f'some_path/that/does/not/exist.{extension}').model_dump()
+
+  # A bare filename with an uppercase extension can be valid base64, so without a
+  # case-insensitive check it is silently accepted instead of raising.
+  with pytest.raises(ValueError, match='does not exist'):
+    Image(value=f'PHOTO.{extension}').model_dump()
+
+
 def test_create_request_serialization():
   request = CreateRequest(model='test-model', from_='base-model', quantize='q4_0', files={'file1': 'content1'}, adapters={'adapter1': 'content1'}, template='test template', license='MIT', system='test system', parameters={'param1': 'value1'})
 


### PR DESCRIPTION

`Image.serialize_model` decides whether a string is a file path or already-base64
data. When a string is not an existing file, it checks the extension to tell "a
path that does not exist" apart from raw base64:

```python
if self.value.split('.')[-1] in ('png', 'jpg', 'jpeg', 'webp'):
    raise ValueError(f'File {self.value} does not exist')
```

That comparison is case-sensitive, but image files routinely carry uppercase
extensions (cameras emit `.JPG`; case-insensitive filesystems treat `.PNG` the
same as `.png`). So a non-existent path with an uppercase extension skips the
`File ... does not exist` branch and falls through to the base64 handling:

- `Image(value='some/path/photo.jpg').model_dump()` correctly raises
  `File some/path/photo.jpg does not exist`.
- `Image(value='some/path/photo.JPG').model_dump()` instead raises the misleading
  `Invalid image data, expected base64 string or path to image file`.
- Worse, a bare filename that happens to be valid base64 is silently accepted:
  `Image(value='PHOTO.PNG').model_dump()` returns the literal string `'PHOTO.PNG'`,
  which then gets sent in the `images` array to `/api/generate` and `/api/chat` as
  garbage image data instead of failing fast.

The fix lowercases the extracted extension before the membership test so
`.PNG/.JPG/.JPEG/.WEBP` behave the same as their lowercase counterparts. Non-image
strings (e.g. `model_v1.2`, plain base64) still fall through to the base64 check
unchanged.

Added a parametrized regression test in `tests/test_type_serialization.py`
covering the uppercase extensions for both a path-shaped value and a bare
filename; both cases fail on the current code and pass with the fix.
