### PR TITLE
fix(types): expose tool call id on Message.ToolCall

### DIFF
--- a/ollama/_types.py
+++ b/ollama/_types.py
@@ -346,6 +346,9 @@ class Message(SubscriptableBaseModel):
       arguments: Mapping[str, Any]
       'Arguments of the function.'
 
+    id: Optional[str] = None
+    'Identifier of the tool call, when provided by the server.'
+
     function: Function
     'Function to be called.'
 

--- a/tests/test_type_serialization.py
+++ b/tests/test_type_serialization.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from ollama._types import CreateRequest, Image
+from ollama._types import CreateRequest, Image, Message
 
 
 def test_image_serialization_bytes():
@@ -29,6 +29,22 @@ def test_image_serialization_long_base64_string():
 def test_image_serialization_plain_string():
   img = Image(value='not a path or base64')
   assert img.model_dump() == 'not a path or base64'  # Should return as-is
+
+
+def test_tool_call_id_round_trips():
+  # The server sends an `id` on each tool call (e.g. "call_p7o2gz50"); it must survive parsing.
+  message = Message(
+    role='assistant',
+    tool_calls=[{'id': 'call_p7o2gz50', 'function': {'name': 'test_function', 'arguments': {'param1': 'test1'}}}],
+  )
+  assert message.tool_calls[0].id == 'call_p7o2gz50'
+  assert message.tool_calls[0].function.name == 'test_function'
+  assert message.model_dump()['tool_calls'][0]['id'] == 'call_p7o2gz50'
+
+
+def test_tool_call_id_defaults_to_none():
+  message = Message(role='assistant', tool_calls=[{'function': {'name': 'f', 'arguments': {}}}])
+  assert message.tool_calls[0].id is None
 
 
 def test_image_serialization_path():


### PR DESCRIPTION
## What & why

The Ollama server returns an `id` on each tool call in the response, e.g. `{"id": "call_p7o2gz50", "function": {...}}`. But `Message.ToolCall` has no `id` field, so it's silently dropped — and it isn't in `model_extra` either — leaving no way to read the tool-call id from Python (#667). That id is needed to correlate a tool call with its result.

## Change

Add an optional `id: Optional[str] = None` to `Message.ToolCall`. It's optional/defaulted so responses that omit it (older servers) keep parsing unchanged.

## Testing

`tests/test_type_serialization.py`: the id round-trips from a raw response and serializes back via `model_dump()`, and defaults to `None` when absent. Full suite: 94 passed. `ruff check` + `ruff format` clean.

Fixes #667
