### PR TITLE
ci: use uv dependabot ecosystem instead of pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
### What

Switch Python dependency updates in `.github/dependabot.yml` from the `pip` ecosystem to the native `uv` ecosystem.

### Why

`uv.lock` is the source of truth, while `requirements.txt` is generated by `uv export`. The lint job verifies that the exported requirements file matches the lockfile.

The current `pip` updater changes `requirements.txt` without updating `uv.lock`, so the export check fails on dependency PRs such as #657 through #661. Using the `uv` ecosystem makes Dependabot update `uv.lock`, keeping the generated requirements file consistent.

### Verification

- `uvx hatch fmt --check -f`
- `uvx hatch fmt --check -l`
- `uv lock --check`
- `uv export >requirements.txt` followed by `git diff --exit-code requirements.txt`
- `uv run --no-sync pytest tests/ -q` (92 passed)