### PR TITLE
fix(example): bound multimodal xkcd requests

### DIFF
--- a/examples/multimodal-generate.py
+++ b/examples/multimodal-generate.py
@@ -5,19 +5,21 @@ import httpx
 
 from ollama import generate
 
-latest = httpx.get('https://xkcd.com/info.0.json')
+HTTP_TIMEOUT = 30
+
+latest = httpx.get('https://xkcd.com/info.0.json', timeout=HTTP_TIMEOUT)
 latest.raise_for_status()
 
 num = int(sys.argv[1]) if len(sys.argv) > 1 else random.randint(1, latest.json().get('num'))
 
-comic = httpx.get(f'https://xkcd.com/{num}/info.0.json')
+comic = httpx.get(f'https://xkcd.com/{num}/info.0.json', timeout=HTTP_TIMEOUT)
 comic.raise_for_status()
 
 print(f'xkcd #{comic.json().get("num")}: {comic.json().get("alt")}')
 print(f'link: https://xkcd.com/{num}')
 print('---')
 
-raw = httpx.get(comic.json().get('img'))
+raw = httpx.get(comic.json().get('img'), timeout=HTTP_TIMEOUT)
 raw.raise_for_status()
 
 for response in generate('llava', 'explain this comic:', images=[raw.content], stream=True):


### PR DESCRIPTION
## Problem

`examples/multimodal-generate.py` fetches xkcd metadata and the comic image using `httpx.get()` without explicit timeouts. If xkcd or the image host accepts a connection but stalls, the example can hang before it ever reaches the Ollama generation call.

## Before / after behavior

Before, the example made three external HTTP requests without a local timeout at the call sites.

After, the example uses one small `HTTP_TIMEOUT` constant for the latest-comic lookup, selected-comic lookup, and image download. The existing `raise_for_status()` behavior is unchanged.

## Verification

- `python -m ruff format examples/multimodal-generate.py`
- `python -m ruff check examples/multimodal-generate.py`
- `python -m py_compile examples/multimodal-generate.py`
- `git diff --check`

I did not run the example end-to-end because it requires a local Ollama `llava` model and live network calls.