### PR TITLE
fix(example): use timezone-aware web search timestamps

### DIFF
--- a/examples/web_search_gpt_oss_helper.py
+++ b/examples/web_search_gpt_oss_helper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 from urllib.parse import urlparse
 
@@ -212,7 +212,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     tb = []
@@ -246,7 +246,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     link_fmt = f'【{link_idx}†{result.title}】\n'
@@ -275,7 +275,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     for url, url_results in fetch_response.get('results', {}).items():
@@ -306,7 +306,7 @@ class Browser:
       text='',
       lines=[],
       links={},
-      fetched_at=datetime.utcnow(),
+      fetched_at=datetime.now(timezone.utc),
     )
 
     max_results = 50


### PR DESCRIPTION
## Problem

`examples/web_search_gpt_oss_helper.py` stores page fetch timestamps with `datetime.utcnow()`. That creates naive datetime objects even though these values represent UTC.

## Before / after

Before this change, helper pages had naive UTC-looking `fetched_at` values.

After this change, the helper uses `datetime.now(timezone.utc)` for search, fetched page, and find-result page timestamps, so `fetched_at` is explicitly UTC-aware.

## Verification

- `python -m py_compile examples/web_search_gpt_oss_helper.py`
- direct smoke check constructing a search results page and asserting `fetched_at` has a UTC offset
- `git diff --check`